### PR TITLE
v2.0 release: Elo difficulty generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ dist/
 /plans/
 /.gocache
 /.golangci-cache
+
+# Temp Scripting and Output directories
+/out
+/tmp

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ puzzletea export-pdf nonogram-mini-set.jsonl -o issue-01-duplex.pdf --shuffle-se
 
 Font license note (Atkinson Hyperlegible Next):
 
-- Follow the SIL OFL 1.1 requirements in `pdfexport/fonts/OFL.txt`.
+- Follow the SIL OFL 1.1 requirements in `export/pdf/fonts/AtkinsonHyperlegibleNext-OFL.txt`.
 - Do not sell the font files by themselves.
 - If redistributing fonts with software, include the copyright notice and OFL text.
 - Modified font versions must keep OFL terms, and modified names must respect Reserved Font Name rules.
@@ -256,96 +256,101 @@ Grow numbered regions so each connected region reaches its exact size.
 
 ![Fillomino](vhs/fillomino.gif)
 
-[Game details and controls](fillomino/README.md)
+[Game details and controls](games/fillomino/README.md)
 
 ### Ripple Effect
 Place digits in cages while keeping matching values outside each other’s ripple distance.
 
 ![Ripple Effect](vhs/rippleeffect.gif)
 
-[Game details and controls](rippleeffect/README.md)
+[Game details and controls](games/rippleeffect/README.md)
 
 ### Nonogram
 Fill cells to match row and column hints.
 
 ![Nonogram](vhs/nonogram.gif)
 
-[Game details and controls](nonogram/README.md)
+[Game details and controls](games/nonogram/README.md)
 
 ### Nurikabe
 Build islands from clues while keeping one connected sea.
 
 ![Nurikabe](vhs/nurikabe.gif)
 
-[Game details and controls](nurikabe/README.md)
+[Game details and controls](games/nurikabe/README.md)
 
 ### Shikaku
 Divide the grid into rectangles, where each rectangle contains exactly the number of cells shown in its clue.
 
 ![Shikaku](vhs/shikaku.gif)
 
-[Game details and controls](shikaku/README.md)
+[Game details and controls](games/shikaku/README.md)
 
 ### Sudoku
 Classic 9x9 number placement puzzle.
 
 ![Sudoku](vhs/sudoku.gif)
 
-[Game details and controls](sudoku/README.md)
+[Game details and controls](games/sudoku/README.md)
 
 ### Sudoku RGB
 Fill the grid with three symbols so every row, column, and box contains `{1,1,1,2,2,2,3,3,3}`.
 
 ![Sudoku RGB](vhs/sudokurgb.gif)
 
-[Game details and controls](sudokurgb/README.md)
+[Game details and controls](games/sudokurgb/README.md)
 
 ### Word Search
 Find hidden words in a letter grid.
 
 ![Word Search](vhs/wordsearch.gif)
 
-[Game details and controls](wordsearch/README.md)
+[Game details and controls](games/wordsearch/README.md)
 
 ### Spell Puzzle
 Connect letters from a fixed bank to reveal a crossword and score bonus words.
 
-[Game details and controls](spellpuzzle/README.md)
+[Game details and controls](games/spellpuzzle/README.md)
 
 ### Hashiwokakero
 Connect islands with bridges.
 
 ![Hashiwokakero](vhs/hashiwokakero.gif)
 
-[Game details and controls](hashiwokakero/README.md)
+[Game details and controls](games/hashiwokakero/README.md)
 
 ### Hitori
 Shade cells to eliminate duplicate numbers.
 
 ![Hitori](vhs/hitori.gif)
 
-[Game details and controls](hitori/README.md)
+[Game details and controls](games/hitori/README.md)
 
 ### Lights Out
 Toggle lights to turn all off.
 
 ![Lights Out](vhs/lightsout.gif)
 
-[Game details and controls](lightsout/README.md)
+[Game details and controls](games/lightsout/README.md)
 
 ### Netwalk
 Rotate network tiles until every computer reaches the server in one loop-free tree.
 
 ![Netwalk](vhs/netwalk.gif)
 
-[Game details and controls](netwalk/README.md)
+[Game details and controls](games/netwalk/README.md)
 
 ### Takuzu
 Fill the grid with two symbols following three simple rules.
 
 ![Takuzu](vhs/takuzu.gif)
 
-[Game details and controls](takuzu/README.md)
+[Game details and controls](games/takuzu/README.md)
+
+### Takuzu+
+Fill the grid with two symbols while obeying the normal Takuzu rules plus fixed relation clues.
+
+[Game details and controls](games/takuzuplus/README.md)
 
 ## Building and Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A terminal-based puzzle game collection built with [Bubble Tea](https://github.com/charmbracelet/bubbletea).
 
-Fifteen puzzle games, multiple difficulty modes, daily and weekly deterministic challenges, XP progression, 365 theme options, and an explicit built-in registry plus metadata catalog for adding new games.
+Fifteen puzzle games, Elo-backed difficulty presets, daily and weekly deterministic challenges, XP progression, 365 theme options, and an explicit built-in registry plus metadata catalog for adding new games.
 
 ![PuzzleTea menu](vhs/menu.gif)
 
@@ -11,10 +11,11 @@ Fifteen puzzle games, multiple difficulty modes, daily and weekly deterministic 
 - **15 puzzle games** -- Fillomino, Netwalk, Nonogram, Nurikabe, Ripple Effect, Shikaku, Sudoku, Sudoku RGB, Spell Puzzle, Word Search, Hashiwokakero, Hitori, Lights Out, Takuzu, Takuzu+
 - **Daily puzzles** -- A unique puzzle generated each day using deterministic seeding. Same date, same puzzle for everyone. Streak tracking rewards consecutive daily completions.
 - **Weekly gauntlet** -- Each ISO calendar week has a shared 99-puzzle ladder. The current week unlocks sequentially from `#01` to `#99`; past weeks can be reviewed from completed saves only.
-- **XP and leveling** -- Per-category levels based on victories. Harder modes yield more XP. Daily puzzles grant 2x XP, and weekly puzzles add slot-based bonus XP.
+- **XP and leveling** -- Per-category levels based on victories. Elo-rated puzzles yield XP from their recorded difficulty. Daily puzzles grant 2x XP, and weekly puzzles add slot-based bonus XP.
 - **Stats dashboard** -- Profile level, daily streak status, weekly completion progress, victory counts, and XP progress bars per category.
 - **365 color themes** -- Live-preview theme picker with WCAG-compliant contrast enforcement. Dark and light themes included.
 - **Mouse support** -- Drag interactions in Nonogram, Nurikabe, Shikaku, Spell Puzzle, and Word Search; click-to-focus in Fillomino, Hashiwokakero, Hitori, Sudoku, Sudoku RGB, Takuzu, and Takuzu+; click-to-rotate in Netwalk; click-to-toggle in Lights Out.
+- **Elo difficulty** -- Puzzle generation can target a `0..3000` Elo difficulty. Named modes remain friendly presets, and generated records store target/actual Elo when available.
 - **Seeded puzzles** -- Share a seed string to generate identical puzzles across sessions and machines.
 - **Save/load persistence** -- Games auto-save to SQLite. Resume any in-progress game by name.
 
@@ -88,11 +89,18 @@ puzzletea
 
 The Play menu includes:
 
-- `Create` for a new puzzle by category and mode
+- `Create` for a new puzzle from a checked pool of games/variants/board sizes, with a target Elo difficulty
 - `Continue` for saved games
 - `Daily` for the shared deterministic daily puzzle
 - `Weekly` for the current or historical weekly gauntlet
-- `Seeded` for a custom deterministic seed
+
+Create replaces the old separate Seeded flow. Check one or more leaf nodes,
+enter an Elo value from `0` to `3000`, and generate one puzzle. If exactly one
+leaf is checked, the seed field is enabled and a nonblank seed resumes the
+matching deterministic save when one already exists. If multiple leaves are
+checked, PuzzleTea picks one checked leaf uniformly at random and disables the
+seed field because the selected game is intentionally random. The Create pool
+and last Elo are saved in `~/.puzzletea/config.json`.
 
 Weekly gauntlets use the ISO week-year format shown in the menu, for example
 `Week 10-2026 # 7`. The `#` value is the currently active weekly challenge for
@@ -115,6 +123,18 @@ puzzletea new hashi "Easy 7x7"
 Mode names are matched case-insensitively after normalizing spaces, hyphens,
 and underscores. Multi-word mode titles usually need quotes.
 
+Target an explicit Elo difficulty for games and modes that support Elo-backed
+generation:
+
+```bash
+puzzletea new sudoku --difficulty 1200
+puzzletea new nonogram classic --difficulty 1800 --with-seed myseed
+```
+
+`--difficulty` accepts integers from `0` through `3000`. When it is present,
+PuzzleTea uses the mode's Elo spawner and records `target_difficulty_elo`,
+`actual_difficulty_elo`, and `difficulty_confidence` in the save metadata.
+
 Resume and manage saved games:
 
 ```bash
@@ -133,6 +153,10 @@ puzzletea new --set-seed myseed
 puzzletea new nonogram epic --with-seed myseed
 ```
 
+For interactive seeded play, use `Create`, check exactly one leaf, and enter the
+seed there. With multiple checked leaves, the Create seed field is intentionally
+disabled.
+
 Export printable puzzle sets to JSONL:
 
 ```bash
@@ -144,6 +168,9 @@ puzzletea new nonogram mini -e 6 -o nonogram-mini-set.jsonl
 
 # Mixed modes within a category (deterministic with --with-seed)
 puzzletea new sudoku --export 10 -o sudoku-mixed.jsonl --with-seed zine-issue-01
+
+# Elo-targeted export
+puzzletea new sudoku --export 10 --difficulty 1500 -o sudoku-1500.jsonl
 ```
 
 Render one or more JSONL packs into a print PDF:
@@ -172,6 +199,10 @@ Font license note (Atkinson Hyperlegible Next):
 - Do not sell the font files by themselves.
 - If redistributing fonts with software, include the copyright notice and OFL text.
 - Modified font versions must keep OFL terms, and modified names must respect Reserved Font Name rules.
+
+JSONL exports include Elo metadata when generation produced a difficulty
+report. PDF ordering and difficulty stars prefer actual Elo, then target Elo,
+then legacy mode-order fallback.
 
 `Lights Out` is currently excluded from export because it does not translate cleanly to paper workflows.
 
@@ -358,6 +389,7 @@ Create a directory (e.g., `mypuzzle/`) with these files:
 | `keys.go` | Game-specific `KeyMap` struct |
 | `style.go` | lipgloss styling and rendering helpers |
 | `generator.go` | Puzzle generation logic (if applicable) |
+| `elo.go` | Elo-targeted generation and `difficulty.Report` scoring |
 | `grid.go` | Grid type and serialization (for grid-based games) |
 | `help.md` | Embedded rules/help content wired into the runtime entry |
 | `print_adapter.go` | Optional printable export adapter for JSONL/PDF support |
@@ -365,7 +397,8 @@ Create a directory (e.g., `mypuzzle/`) with these files:
 | `README.md` | Game docs: rules, controls table, modes table, quick start examples |
 
 Use `gameentry.BuildModeDefs(Modes)` and `gameentry.NewEntry(...)` so the
-package exposes both metadata and its validated runtime wiring.
+package exposes both metadata and its validated runtime wiring. If a mode has a
+preset Elo, its runtime mode must implement `game.EloSpawner`.
 
 ### 2. Wire it into the built-in registry
 
@@ -379,6 +412,7 @@ The game package's `Definition` owns:
 - description
 - aliases
 - menu modes
+- preset Elo values for modes
 - daily-eligible modes
 - help content
 - save/import function
@@ -404,6 +438,17 @@ See any existing game package (e.g., `nonogram/`) for the full pattern, and `AGE
 ## License
 
 [MIT](LICENSE)
+
+## Research References
+
+Elo difficulty scoring and game-specific heuristics were informed by public
+puzzle implementations and solver documentation, including Simon Tatham's
+[Portable Puzzle Collection](https://www.chiark.greenend.org.uk/~sgtatham/puzzles/)
+and [source repository](https://git.tartarus.org/?p=simon/puzzles.git),
+[Copris puzzle solvers](https://cspsat.gitlab.io/copris-puzzles/),
+[QQWing Sudoku](https://qqwing.com/), Jaap Scherphuis'
+[Lights Out notes](https://www.jaapsch.net/puzzles/lights.htm), and public
+[Nikoli puzzle rules](https://www.nikoli.co.jp/en/puzzles/).
 
 ## Built With
 

--- a/app/create_state.go
+++ b/app/create_state.go
@@ -1,0 +1,379 @@
+package app
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/FelineStateMachine/puzzletea/config"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+	"github.com/FelineStateMachine/puzzletea/puzzle"
+	"github.com/FelineStateMachine/puzzletea/registry"
+
+	"charm.land/bubbles/v2/textinput"
+)
+
+const defaultCreateElo = 1200
+
+var boardSizePattern = regexp.MustCompile(`(?i)(\d+)\s*[x×]\s*(\d+)`)
+
+type createState struct {
+	tree      []createTreeNode
+	checked   map[string]bool
+	expanded  map[string]bool
+	cursor    int
+	eloInput  textinput.Model
+	seedInput textinput.Model
+	focus     createFocus
+}
+
+type createFocus int
+
+const (
+	createFocusTree createFocus = iota
+	createFocusElo
+	createFocusSeed
+	createFocusGenerate
+)
+
+type createTreeNode struct {
+	id       string
+	title    string
+	leaf     *createLeaf
+	children []createTreeNode
+}
+
+type createLeaf struct {
+	id        string
+	title     string
+	gameType  string
+	modeTitle string
+	modes     []registry.ModeEntry
+}
+
+type createVisibleNode struct {
+	node  createTreeNode
+	depth int
+}
+
+func newCreateState(cfg config.CreateConfig, width int) createState {
+	elo := cfg.Elo
+	if err := difficulty.ValidateElo(difficulty.Elo(elo)); err != nil {
+		elo = defaultCreateElo
+	}
+
+	eloInput := textinput.New()
+	eloInput.Prompt = ""
+	eloInput.CharLimit = 4
+	eloInput.SetWidth(8)
+	eloInput.SetValue(strconv.Itoa(elo))
+
+	seedInput := textinput.New()
+	seedInput.Prompt = ""
+	seedInput.Placeholder = "optional seed"
+	seedInput.CharLimit = 64
+	seedInput.SetWidth(min(width, 48))
+
+	state := createState{
+		tree:      buildCreateTree(registry.Entries()),
+		checked:   make(map[string]bool),
+		expanded:  make(map[string]bool),
+		eloInput:  eloInput,
+		seedInput: seedInput,
+		focus:     createFocusTree,
+	}
+	for _, id := range cfg.SelectedLeafIDs {
+		state.checked[id] = true
+		state.expandAncestors(id)
+	}
+	if len(state.checked) == 0 {
+		state.expandTopLevel()
+	}
+	return state
+}
+
+func buildCreateTree(entries []registry.Entry) []createTreeNode {
+	builders := make(map[string]*createNodeBuilder)
+	order := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		topTitle, branchTitle := createGrouping(entry.Definition.Name)
+		topID := "group:" + puzzle.NormalizeName(topTitle)
+		builder, ok := builders[topID]
+		if !ok {
+			builder = &createNodeBuilder{id: topID, title: topTitle}
+			builders[topID] = builder
+			order = append(order, topID)
+		}
+		builder.addBranch(entry, branchTitle)
+	}
+
+	nodes := make([]createTreeNode, 0, len(order))
+	for _, id := range order {
+		nodes = append(nodes, builders[id].node())
+	}
+	return nodes
+}
+
+type createNodeBuilder struct {
+	id       string
+	title    string
+	branches []createTreeNode
+}
+
+func (b *createNodeBuilder) addBranch(entry registry.Entry, branchTitle string) {
+	leaves := createLeavesForEntry(entry, branchTitle)
+	if branchTitle == "" {
+		b.branches = append(b.branches, leaves...)
+		return
+	}
+
+	branchID := b.id + "/branch:" + puzzle.NormalizeName(branchTitle)
+	b.branches = append(b.branches, createTreeNode{
+		id:       branchID,
+		title:    branchTitle,
+		children: leaves,
+	})
+}
+
+func (b *createNodeBuilder) node() createTreeNode {
+	return createTreeNode{id: b.id, title: b.title, children: b.branches}
+}
+
+func createGrouping(gameType string) (topTitle, branchTitle string) {
+	switch gameType {
+	case "Takuzu", "Takuzu+":
+		return "Takuzu", gameType
+	case "Sudoku", "Sudoku RGB":
+		return "Sudoku", gameType
+	default:
+		return gameType, ""
+	}
+}
+
+func createLeavesForEntry(entry registry.Entry, branchTitle string) []createTreeNode {
+	groups := make(map[string][]registry.ModeEntry)
+	order := make([]string, 0, len(entry.Modes))
+	for _, mode := range entry.Modes {
+		if mode.Elo == nil {
+			continue
+		}
+		title := createLeafTitle(entry.Definition.Name, entry.Definition.Description, mode.Definition.Title, mode.Definition.Description)
+		if _, ok := groups[title]; !ok {
+			order = append(order, title)
+		}
+		groups[title] = append(groups[title], mode)
+	}
+
+	nodes := make([]createTreeNode, 0, len(order))
+	for _, title := range order {
+		id := createLeafID(entry.Definition.ID, branchTitle, title)
+		modes := groups[title]
+		nodes = append(nodes, createTreeNode{
+			id:    id,
+			title: title,
+			leaf: &createLeaf{
+				id:        id,
+				title:     title,
+				gameType:  entry.Definition.Name,
+				modeTitle: modes[0].Definition.Title,
+				modes:     modes,
+			},
+		})
+	}
+	return nodes
+}
+
+func createLeafID(gameID puzzle.GameID, branchTitle, title string) string {
+	parts := []string{string(gameID)}
+	if branchTitle != "" {
+		parts = append(parts, puzzle.NormalizeName(branchTitle))
+	}
+	parts = append(parts, puzzle.NormalizeName(title))
+	return strings.Join(parts, "/")
+}
+
+func createLeafTitle(gameType, gameDescription, modeTitle, modeDescription string) string {
+	if size := firstBoardSize(modeTitle); size != "" {
+		return size
+	}
+	if size := firstBoardSize(modeDescription); size != "" {
+		return size
+	}
+	if gameType == "Sudoku RGB" {
+		return "9x9"
+	}
+	if size := firstBoardSize(gameDescription); size != "" {
+		return size
+	}
+	return modeTitle
+}
+
+func firstBoardSize(s string) string {
+	match := boardSizePattern.FindStringSubmatch(s)
+	if len(match) != 3 {
+		return ""
+	}
+	return match[1] + "x" + match[2]
+}
+
+func (s createState) selectedLeaves() []createLeaf {
+	leaves := make([]createLeaf, 0, len(s.checked))
+	var walk func([]createTreeNode)
+	walk = func(nodes []createTreeNode) {
+		for _, node := range nodes {
+			if node.leaf != nil && s.checked[node.leaf.id] {
+				leaves = append(leaves, *node.leaf)
+			}
+			walk(node.children)
+		}
+	}
+	walk(s.tree)
+	return leaves
+}
+
+func (s createState) selectedLeafIDs() []string {
+	ids := make([]string, 0, len(s.checked))
+	for id, checked := range s.checked {
+		if checked {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (s createState) selectedCount() int {
+	count := 0
+	for _, checked := range s.checked {
+		if checked {
+			count++
+		}
+	}
+	return count
+}
+
+func (s createState) descendantLeafCounts(node createTreeNode) (selected, total int) {
+	var walk func(createTreeNode)
+	walk = func(node createTreeNode) {
+		if node.leaf != nil {
+			total++
+			if s.checked[node.leaf.id] {
+				selected++
+			}
+			return
+		}
+		for _, child := range node.children {
+			walk(child)
+		}
+	}
+	walk(node)
+	return selected, total
+}
+
+func (s *createState) toggleDescendantLeaves(node createTreeNode) {
+	selected, total := s.descendantLeafCounts(node)
+	if total == 0 {
+		return
+	}
+	checked := selected != total
+	var walk func(createTreeNode)
+	walk = func(node createTreeNode) {
+		if node.leaf != nil {
+			s.checked[node.leaf.id] = checked
+			return
+		}
+		for _, child := range node.children {
+			walk(child)
+		}
+	}
+	walk(node)
+}
+
+func (s createState) seedEnabled() bool {
+	return s.selectedCount() == 1
+}
+
+func (s createState) elo() (difficulty.Elo, error) {
+	value, err := strconv.Atoi(strings.TrimSpace(s.eloInput.Value()))
+	if err != nil {
+		return 0, fmt.Errorf("Elo must be a number")
+	}
+	elo := difficulty.Elo(value)
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return 0, err
+	}
+	return elo, nil
+}
+
+func (s createState) visibleNodes() []createVisibleNode {
+	visible := make([]createVisibleNode, 0)
+	var walk func([]createTreeNode, int)
+	walk = func(nodes []createTreeNode, depth int) {
+		for _, node := range nodes {
+			visible = append(visible, createVisibleNode{node: node, depth: depth})
+			if node.leaf == nil && s.expanded[node.id] {
+				walk(node.children, depth+1)
+			}
+		}
+	}
+	walk(s.tree, 0)
+	return visible
+}
+
+func (s *createState) expandTopLevel() {
+	for _, node := range s.tree {
+		s.expanded[node.id] = false
+	}
+}
+
+func (s *createState) expandAncestors(leafID string) {
+	var walk func([]createTreeNode, []string) bool
+	walk = func(nodes []createTreeNode, ancestors []string) bool {
+		for _, node := range nodes {
+			if node.id == leafID {
+				for _, id := range ancestors {
+					s.expanded[id] = true
+				}
+				return true
+			}
+			if walk(node.children, append(ancestors, node.id)) {
+				return true
+			}
+		}
+		return false
+	}
+	walk(s.tree, nil)
+}
+
+func (s createState) resolveLeafMode(leaf createLeaf, elo difficulty.Elo) (game.EloSpawner, string, error) {
+	if len(leaf.modes) == 0 {
+		return nil, "", fmt.Errorf("no Elo-capable modes for %s", leaf.title)
+	}
+	best := leaf.modes[0]
+	bestDistance := createPresetDistance(best, elo)
+	for _, mode := range leaf.modes[1:] {
+		distance := createPresetDistance(mode, elo)
+		if distance < bestDistance {
+			best = mode
+			bestDistance = distance
+		}
+	}
+	if best.Elo == nil {
+		return nil, "", fmt.Errorf("%s %s does not support Elo generation", leaf.gameType, leaf.title)
+	}
+	return best.Elo, best.Definition.Title, nil
+}
+
+func createPresetDistance(mode registry.ModeEntry, elo difficulty.Elo) int {
+	if mode.Definition.PresetElo == nil {
+		return 0
+	}
+	delta := int(*mode.Definition.PresetElo - elo)
+	if delta < 0 {
+		return -delta
+	}
+	return delta
+}

--- a/app/create_state.go
+++ b/app/create_state.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,8 +16,6 @@ import (
 )
 
 const defaultCreateElo = 1200
-
-var boardSizePattern = regexp.MustCompile(`(?i)(\d+)\s*[x×]\s*(\d+)`)
 
 type createState struct {
 	tree      []createTreeNode
@@ -47,11 +44,10 @@ type createTreeNode struct {
 }
 
 type createLeaf struct {
-	id        string
-	title     string
-	gameType  string
-	modeTitle string
-	modes     []registry.ModeEntry
+	id       string
+	title    string
+	gameType string
+	variant  registry.VariantEntry
 }
 
 type createVisibleNode struct {
@@ -154,32 +150,21 @@ func createGrouping(gameType string) (topTitle, branchTitle string) {
 }
 
 func createLeavesForEntry(entry registry.Entry, branchTitle string) []createTreeNode {
-	groups := make(map[string][]registry.ModeEntry)
-	order := make([]string, 0, len(entry.Modes))
-	for _, mode := range entry.Modes {
-		if mode.Elo == nil {
+	nodes := make([]createTreeNode, 0, len(entry.Variants))
+	for _, variant := range entry.Variants {
+		if variant.Elo == nil {
 			continue
 		}
-		title := createLeafTitle(entry.Definition.Name, entry.Definition.Description, mode.Definition.Title, mode.Definition.Description)
-		if _, ok := groups[title]; !ok {
-			order = append(order, title)
-		}
-		groups[title] = append(groups[title], mode)
-	}
-
-	nodes := make([]createTreeNode, 0, len(order))
-	for _, title := range order {
+		title := variant.Definition.Title
 		id := createLeafID(entry.Definition.ID, branchTitle, title)
-		modes := groups[title]
 		nodes = append(nodes, createTreeNode{
 			id:    id,
 			title: title,
 			leaf: &createLeaf{
-				id:        id,
-				title:     title,
-				gameType:  entry.Definition.Name,
-				modeTitle: modes[0].Definition.Title,
-				modes:     modes,
+				id:       id,
+				title:    title,
+				gameType: entry.Definition.Name,
+				variant:  variant,
 			},
 		})
 	}
@@ -193,30 +178,6 @@ func createLeafID(gameID puzzle.GameID, branchTitle, title string) string {
 	}
 	parts = append(parts, puzzle.NormalizeName(title))
 	return strings.Join(parts, "/")
-}
-
-func createLeafTitle(gameType, gameDescription, modeTitle, modeDescription string) string {
-	if size := firstBoardSize(modeTitle); size != "" {
-		return size
-	}
-	if size := firstBoardSize(modeDescription); size != "" {
-		return size
-	}
-	if gameType == "Sudoku RGB" {
-		return "9x9"
-	}
-	if size := firstBoardSize(gameDescription); size != "" {
-		return size
-	}
-	return modeTitle
-}
-
-func firstBoardSize(s string) string {
-	match := boardSizePattern.FindStringSubmatch(s)
-	if len(match) != 3 {
-		return ""
-	}
-	return match[1] + "x" + match[2]
 }
 
 func (s createState) selectedLeaves() []createLeaf {
@@ -348,32 +309,9 @@ func (s *createState) expandAncestors(leafID string) {
 	walk(s.tree, nil)
 }
 
-func (s createState) resolveLeafMode(leaf createLeaf, elo difficulty.Elo) (game.EloSpawner, string, error) {
-	if len(leaf.modes) == 0 {
-		return nil, "", fmt.Errorf("no Elo-capable modes for %s", leaf.title)
-	}
-	best := leaf.modes[0]
-	bestDistance := createPresetDistance(best, elo)
-	for _, mode := range leaf.modes[1:] {
-		distance := createPresetDistance(mode, elo)
-		if distance < bestDistance {
-			best = mode
-			bestDistance = distance
-		}
-	}
-	if best.Elo == nil {
+func (s createState) resolveLeafVariant(leaf createLeaf, elo difficulty.Elo) (game.EloSpawner, string, error) {
+	if leaf.variant.Elo == nil {
 		return nil, "", fmt.Errorf("%s %s does not support Elo generation", leaf.gameType, leaf.title)
 	}
-	return best.Elo, best.Definition.Title, nil
-}
-
-func createPresetDistance(mode registry.ModeEntry, elo difficulty.Elo) int {
-	if mode.Definition.PresetElo == nil {
-		return 0
-	}
-	delta := int(*mode.Definition.PresetElo - elo)
-	if delta < 0 {
-		return -delta
-	}
-	return delta
+	return leaf.variant.Elo, leaf.variant.Definition.Title, nil
 }

--- a/app/create_state.go
+++ b/app/create_state.go
@@ -73,8 +73,10 @@ func newCreateState(cfg config.CreateConfig, width int) createState {
 	seedInput.CharLimit = 64
 	seedInput.SetWidth(min(width, 48))
 
+	tree := buildCreateTree(registry.Entries())
+	validLeafIDs := createLeafIDSet(tree)
 	state := createState{
-		tree:      buildCreateTree(registry.Entries()),
+		tree:      tree,
 		checked:   make(map[string]bool),
 		expanded:  make(map[string]bool),
 		eloInput:  eloInput,
@@ -82,6 +84,9 @@ func newCreateState(cfg config.CreateConfig, width int) createState {
 		focus:     createFocusTree,
 	}
 	for _, id := range cfg.SelectedLeafIDs {
+		if !validLeafIDs[id] {
+			continue
+		}
 		state.checked[id] = true
 		state.expandAncestors(id)
 	}
@@ -127,6 +132,10 @@ func (b *createNodeBuilder) addBranch(entry registry.Entry, branchTitle string) 
 	}
 
 	branchID := b.id + "/branch:" + puzzle.NormalizeName(branchTitle)
+	if len(leaves) == 1 {
+		b.branches = append(b.branches, leaves[0])
+		return
+	}
 	b.branches = append(b.branches, createTreeNode{
 		id:       branchID,
 		title:    branchTitle,
@@ -135,6 +144,9 @@ func (b *createNodeBuilder) addBranch(entry registry.Entry, branchTitle string) 
 }
 
 func (b *createNodeBuilder) node() createTreeNode {
+	if len(b.branches) == 1 && b.branches[0].leaf != nil {
+		return b.branches[0]
+	}
 	return createTreeNode{id: b.id, title: b.title, children: b.branches}
 }
 
@@ -196,24 +208,17 @@ func (s createState) selectedLeaves() []createLeaf {
 }
 
 func (s createState) selectedLeafIDs() []string {
-	ids := make([]string, 0, len(s.checked))
-	for id, checked := range s.checked {
-		if checked {
-			ids = append(ids, id)
-		}
+	leaves := s.selectedLeaves()
+	ids := make([]string, 0, len(leaves))
+	for _, leaf := range leaves {
+		ids = append(ids, leaf.id)
 	}
 	sort.Strings(ids)
 	return ids
 }
 
 func (s createState) selectedCount() int {
-	count := 0
-	for _, checked := range s.checked {
-		if checked {
-			count++
-		}
-	}
-	return count
+	return len(s.selectedLeaves())
 }
 
 func (s createState) descendantLeafCounts(node createTreeNode) (selected, total int) {
@@ -314,4 +319,20 @@ func (s createState) resolveLeafVariant(leaf createLeaf, elo difficulty.Elo) (ga
 		return nil, "", fmt.Errorf("%s %s does not support Elo generation", leaf.gameType, leaf.title)
 	}
 	return leaf.variant.Elo, leaf.variant.Definition.Title, nil
+}
+
+func createLeafIDSet(nodes []createTreeNode) map[string]bool {
+	ids := make(map[string]bool)
+	var walk func([]createTreeNode)
+	walk = func(nodes []createTreeNode) {
+		for _, node := range nodes {
+			if node.leaf != nil {
+				ids[node.leaf.id] = true
+				continue
+			}
+			walk(node.children)
+		}
+	}
+	walk(nodes)
+	return ids
 }

--- a/app/create_state_test.go
+++ b/app/create_state_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/config"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestCreateStateStartsCollapsedAndRestoresCheckedLeaves(t *testing.T) {
+	const leafID = "nonogram/5x5"
+	state := newCreateState(config.CreateConfig{
+		SelectedLeafIDs: []string{leafID},
+		Elo:             1500,
+	}, 80)
+
+	if !state.checked[leafID] {
+		t.Fatalf("expected %q to be checked", leafID)
+	}
+	if got := state.eloInput.Value(); got != "1500" {
+		t.Fatalf("elo input = %q, want 1500", got)
+	}
+	if len(state.visibleNodes()) <= len(state.tree) {
+		t.Fatalf("expected restored leaf ancestors to be expanded")
+	}
+}
+
+func TestCreateStateDefaultStartsCollapsed(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+
+	if len(state.visibleNodes()) != len(state.tree) {
+		t.Fatalf("visible node count = %d, want %d", len(state.visibleNodes()), len(state.tree))
+	}
+}
+
+func TestCreateTreeGroupsTakuzuAndSudokuVariants(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+
+	takuzu := requireCreateNode(t, state.tree, "Takuzu")
+	if !hasCreateChild(takuzu, "Takuzu") || !hasCreateChild(takuzu, "Takuzu+") {
+		t.Fatalf("Takuzu group children = %#v, want Takuzu and Takuzu+", childTitles(takuzu))
+	}
+
+	sudoku := requireCreateNode(t, state.tree, "Sudoku")
+	if !hasCreateChild(sudoku, "Sudoku") || !hasCreateChild(sudoku, "Sudoku RGB") {
+		t.Fatalf("Sudoku group children = %#v, want Sudoku and Sudoku RGB", childTitles(sudoku))
+	}
+}
+
+func TestCreateTreeCollapsesNonogramByBoardSize(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+
+	want := []string{"5x5", "10x10", "15x15", "20x20"}
+	got := childTitles(nonogram)
+	if len(got) != len(want) {
+		t.Fatalf("Nonogram leaves = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Nonogram leaves = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestCreateResolveLeafModeUsesNearestPresetElo(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	leaf := requireCreateNode(t, nonogram.children, "5x5").leaf
+	if leaf == nil {
+		t.Fatal("5x5 node is not a leaf")
+	}
+
+	_, modeTitle, err := state.resolveLeafMode(*leaf, difficulty.Elo(700))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modeTitle != "Teaser" {
+		t.Fatalf("modeTitle = %q, want Teaser", modeTitle)
+	}
+}
+
+func TestCreateStateDescendantLeafCountsIncludeCollapsedDescendants(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	state.checked[nonogram.children[0].leaf.id] = true
+
+	selected, total := state.descendantLeafCounts(nonogram)
+	if selected != 1 || total != len(nonogram.children) {
+		t.Fatalf("descendant counts = %d/%d, want 1/%d", selected, total, len(nonogram.children))
+	}
+}
+
+func TestCreateStateToggleDescendantLeavesSelectsAllWhenAnyUnchecked(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	state.checked[nonogram.children[0].leaf.id] = true
+
+	state.toggleDescendantLeaves(nonogram)
+
+	selected, total := state.descendantLeafCounts(nonogram)
+	if selected != total || total == 0 {
+		t.Fatalf("descendant counts after select-all = %d/%d, want all selected", selected, total)
+	}
+}
+
+func TestCreateStateToggleDescendantLeavesClearsFullySelectedParent(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	state.toggleDescendantLeaves(nonogram)
+
+	state.toggleDescendantLeaves(nonogram)
+
+	selected, total := state.descendantLeafCounts(nonogram)
+	if selected != 0 || total == 0 {
+		t.Fatalf("descendant counts after clear = %d/%d, want 0 selected", selected, total)
+	}
+}
+
+func TestCreateStateToggleDescendantLeavesWorksForNestedVariantBranch(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	takuzu := requireCreateNode(t, state.tree, "Takuzu")
+	takuzuPlus := requireCreateNode(t, takuzu.children, "Takuzu+")
+
+	state.toggleDescendantLeaves(takuzuPlus)
+
+	selected, total := state.descendantLeafCounts(takuzuPlus)
+	if selected != total || total == 0 {
+		t.Fatalf("Takuzu+ descendant counts after toggle = %d/%d, want all selected", selected, total)
+	}
+}
+
+func requireCreateNode(t *testing.T, nodes []createTreeNode, title string) createTreeNode {
+	t.Helper()
+	for _, node := range nodes {
+		if node.title == title {
+			return node
+		}
+	}
+	t.Fatalf("missing create node %q in %#v", title, childTitles(createTreeNode{children: nodes}))
+	return createTreeNode{}
+}
+
+func hasCreateChild(node createTreeNode, title string) bool {
+	for _, child := range node.children {
+		if child.title == title {
+			return true
+		}
+	}
+	return false
+}
+
+func childTitles(node createTreeNode) []string {
+	titles := make([]string, 0, len(node.children))
+	for _, child := range node.children {
+		titles = append(titles, child.title)
+	}
+	return titles
+}

--- a/app/create_state_test.go
+++ b/app/create_state_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateStateStartsCollapsedAndRestoresCheckedLeaves(t *testing.T) {
-	const leafID = "nonogram/5x5"
+	const leafID = "nonogram/nonogram"
 	state := newCreateState(config.CreateConfig{
 		SelectedLeafIDs: []string{leafID},
 		Elo:             1500,
@@ -47,11 +47,11 @@ func TestCreateTreeGroupsTakuzuAndSudokuVariants(t *testing.T) {
 	}
 }
 
-func TestCreateTreeCollapsesNonogramByBoardSize(t *testing.T) {
+func TestCreateTreeListsNonogramRuleVariant(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
 
-	want := []string{"5x5", "10x10", "15x15", "20x20"}
+	want := []string{"Nonogram"}
 	got := childTitles(nonogram)
 	if len(got) != len(want) {
 		t.Fatalf("Nonogram leaves = %#v, want %#v", got, want)
@@ -63,20 +63,20 @@ func TestCreateTreeCollapsesNonogramByBoardSize(t *testing.T) {
 	}
 }
 
-func TestCreateResolveLeafModeUsesNearestPresetElo(t *testing.T) {
+func TestCreateResolveLeafVariantUsesSelectedVariant(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
-	leaf := requireCreateNode(t, nonogram.children, "5x5").leaf
+	leaf := requireCreateNode(t, nonogram.children, "Nonogram").leaf
 	if leaf == nil {
-		t.Fatal("5x5 node is not a leaf")
+		t.Fatal("Nonogram node is not a leaf")
 	}
 
-	_, modeTitle, err := state.resolveLeafMode(*leaf, difficulty.Elo(700))
+	_, modeTitle, err := state.resolveLeafVariant(*leaf, difficulty.Elo(700))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if modeTitle != "Teaser" {
-		t.Fatalf("modeTitle = %q, want Teaser", modeTitle)
+	if modeTitle != "Nonogram" {
+		t.Fatalf("modeTitle = %q, want Nonogram", modeTitle)
 	}
 }
 
@@ -93,12 +93,12 @@ func TestCreateStateDescendantLeafCountsIncludeCollapsedDescendants(t *testing.T
 
 func TestCreateStateToggleDescendantLeavesSelectsAllWhenAnyUnchecked(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
-	nonogram := requireCreateNode(t, state.tree, "Nonogram")
-	state.checked[nonogram.children[0].leaf.id] = true
+	sudoku := requireCreateNode(t, state.tree, "Sudoku")
+	state.checked[firstDescendantLeafID(t, sudoku.children[0])] = true
 
-	state.toggleDescendantLeaves(nonogram)
+	state.toggleDescendantLeaves(sudoku)
 
-	selected, total := state.descendantLeafCounts(nonogram)
+	selected, total := state.descendantLeafCounts(sudoku)
 	if selected != total || total == 0 {
 		t.Fatalf("descendant counts after select-all = %d/%d, want all selected", selected, total)
 	}
@@ -156,4 +156,18 @@ func childTitles(node createTreeNode) []string {
 		titles = append(titles, child.title)
 	}
 	return titles
+}
+
+func firstDescendantLeafID(t *testing.T, node createTreeNode) string {
+	t.Helper()
+	if node.leaf != nil {
+		return node.leaf.id
+	}
+	for _, child := range node.children {
+		if id := firstDescendantLeafID(t, child); id != "" {
+			return id
+		}
+	}
+	t.Fatalf("node %q has no descendant leaf", node.title)
+	return ""
 }

--- a/app/create_state_test.go
+++ b/app/create_state_test.go
@@ -20,8 +20,32 @@ func TestCreateStateStartsCollapsedAndRestoresCheckedLeaves(t *testing.T) {
 	if got := state.eloInput.Value(); got != "1500" {
 		t.Fatalf("elo input = %q, want 1500", got)
 	}
-	if len(state.visibleNodes()) <= len(state.tree) {
-		t.Fatalf("expected restored leaf ancestors to be expanded")
+	for _, item := range state.visibleNodes() {
+		if item.node.leaf != nil && item.node.leaf.id == leafID {
+			return
+		}
+	}
+	t.Fatalf("visible nodes = %#v, want restored top-level leaf %q", state.visibleNodes(), leafID)
+}
+
+func TestCreateStateIgnoresUnknownRestoredLeafIDs(t *testing.T) {
+	const validLeafID = "nonogram/nonogram"
+	state := newCreateState(config.CreateConfig{
+		SelectedLeafIDs: []string{
+			"nonogram/5x5",
+			validLeafID,
+			"stale/game/mode",
+		},
+	}, 80)
+
+	if got := state.selectedCount(); got != 1 {
+		t.Fatalf("selected count = %d, want 1", got)
+	}
+	if got := state.selectedLeafIDs(); len(got) != 1 || got[0] != validLeafID {
+		t.Fatalf("selected leaf IDs = %#v, want [%q]", got, validLeafID)
+	}
+	if len(state.checked) != 1 || !state.checked[validLeafID] {
+		t.Fatalf("checked map = %#v, want only %q", state.checked, validLeafID)
 	}
 }
 
@@ -40,33 +64,39 @@ func TestCreateTreeGroupsTakuzuAndSudokuVariants(t *testing.T) {
 	if !hasCreateChild(takuzu, "Takuzu") || !hasCreateChild(takuzu, "Takuzu+") {
 		t.Fatalf("Takuzu group children = %#v, want Takuzu and Takuzu+", childTitles(takuzu))
 	}
+	for _, child := range takuzu.children {
+		if child.leaf == nil {
+			t.Fatalf("Takuzu child %q = %#v, want leaf", child.title, child)
+		}
+	}
 
 	sudoku := requireCreateNode(t, state.tree, "Sudoku")
 	if !hasCreateChild(sudoku, "Sudoku") || !hasCreateChild(sudoku, "Sudoku RGB") {
 		t.Fatalf("Sudoku group children = %#v, want Sudoku and Sudoku RGB", childTitles(sudoku))
 	}
+	for _, child := range sudoku.children {
+		if child.leaf == nil {
+			t.Fatalf("Sudoku child %q = %#v, want leaf", child.title, child)
+		}
+	}
 }
 
-func TestCreateTreeListsNonogramRuleVariant(t *testing.T) {
+func TestCreateTreePromotesSingleVariantGameToTopLevelLeaf(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
 
-	want := []string{"Nonogram"}
-	got := childTitles(nonogram)
-	if len(got) != len(want) {
-		t.Fatalf("Nonogram leaves = %#v, want %#v", got, want)
+	if nonogram.leaf == nil {
+		t.Fatalf("Nonogram node = %#v, want top-level leaf", nonogram)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("Nonogram leaves = %#v, want %#v", got, want)
-		}
+	if len(nonogram.children) != 0 {
+		t.Fatalf("Nonogram children = %#v, want none", childTitles(nonogram))
 	}
 }
 
 func TestCreateResolveLeafVariantUsesSelectedVariant(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
-	leaf := requireCreateNode(t, nonogram.children, "Nonogram").leaf
+	leaf := nonogram.leaf
 	if leaf == nil {
 		t.Fatal("Nonogram node is not a leaf")
 	}
@@ -83,11 +113,11 @@ func TestCreateResolveLeafVariantUsesSelectedVariant(t *testing.T) {
 func TestCreateStateDescendantLeafCountsIncludeCollapsedDescendants(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
-	state.checked[nonogram.children[0].leaf.id] = true
+	state.checked[nonogram.leaf.id] = true
 
 	selected, total := state.descendantLeafCounts(nonogram)
-	if selected != 1 || total != len(nonogram.children) {
-		t.Fatalf("descendant counts = %d/%d, want 1/%d", selected, total, len(nonogram.children))
+	if selected != 1 || total != 1 {
+		t.Fatalf("descendant counts = %d/%d, want 1/1", selected, total)
 	}
 }
 
@@ -117,7 +147,7 @@ func TestCreateStateToggleDescendantLeavesClearsFullySelectedParent(t *testing.T
 	}
 }
 
-func TestCreateStateToggleDescendantLeavesWorksForNestedVariantBranch(t *testing.T) {
+func TestCreateStateToggleDescendantLeavesWorksForGroupedLeaf(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	takuzu := requireCreateNode(t, state.tree, "Takuzu")
 	takuzuPlus := requireCreateNode(t, takuzu.children, "Takuzu+")

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -25,7 +25,7 @@ func TestHandleExportEnterLoadsPersistedDefaults(t *testing.T) {
 				PDFOutputPath: filepath.Join(tmp, "saved.pdf"),
 				Counts: map[puzzle.GameID]map[puzzle.ModeID]int{
 					puzzle.CanonicalGameID("Sudoku"): {
-						puzzle.CanonicalModeID("Easy"): 4,
+						puzzle.CanonicalModeID("Sudoku"): 4,
 					},
 				},
 			},

--- a/app/handle_create.go
+++ b/app/handle_create.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"math/rand/v2"
+
+	"github.com/FelineStateMachine/puzzletea/config"
+	sessionflow "github.com/FelineStateMachine/puzzletea/session"
+	"github.com/FelineStateMachine/puzzletea/store"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func (m model) handleCreateGenerate() (model, tea.Cmd) {
+	leaves := m.create.selectedLeaves()
+	if len(leaves) == 0 {
+		return m.setErrorf("Select at least one puzzle."), nil
+	}
+
+	elo, err := m.create.elo()
+	if err != nil {
+		return m.setErrorf("Invalid Elo: %v", err), nil
+	}
+
+	leaf := leaves[m.createChoiceIndex(len(leaves))]
+	spawner, modeTitle, err := m.create.resolveLeafMode(leaf, elo)
+	if err != nil {
+		return m.setErrorf("Could not prepare puzzle: %v", err), nil
+	}
+
+	if err := m.persistCreatePreset(); err != nil {
+		return m.setErrorf("Could not save create settings: %v", err), nil
+	}
+
+	seed := ""
+	name := sessionflow.GenerateUniqueName(m.store)
+	run := store.NormalRunMetadata()
+	if len(leaves) == 1 {
+		seed = normalizedCreateSeed(m.create.seedInput.Value())
+	}
+	if seed != "" {
+		name = sessionflow.SeededNameForCreateLeaf(seed, leaf.gameType, leaf.id, elo)
+		run = store.SeededRunMetadata(seed)
+		rec, err := m.store.GetDailyGame(name)
+		if err != nil {
+			return m.setErrorf("Could not check saved seeded puzzle: %v", err), nil
+		}
+		if rec != nil {
+			var resumed bool
+			m, resumed = m.importAndActivateRecord(*rec)
+			if resumed {
+				if err := sessionflow.ResumeAbandonedDeterministicRecord(m.store, rec); err != nil {
+					m = m.setErrorf("%v", err)
+				}
+			}
+			return m, nil
+		}
+	} else {
+		seed = name
+	}
+
+	cmd := newSessionController(&m).startEloSpawn(spawner, seed, elo, spawnRequest{
+		source:      spawnSourceNormal,
+		name:        name,
+		gameType:    leaf.gameType,
+		modeTitle:   modeTitle,
+		run:         run,
+		returnState: createView,
+		exitState:   mainMenuView,
+	})
+	return m, cmd
+}
+
+func (m model) createChoiceIndex(n int) int {
+	if n <= 1 {
+		return 0
+	}
+	if m.createRandIndex != nil {
+		idx := m.createRandIndex(n)
+		if idx < 0 || idx >= n {
+			return 0
+		}
+		return idx
+	}
+	return rand.IntN(n)
+}
+
+func (m model) persistCreatePresetIfValid() model {
+	if len(m.create.selectedLeaves()) == 0 {
+		return m
+	}
+	if _, err := m.create.elo(); err != nil {
+		return m
+	}
+	if err := m.persistCreatePreset(); err != nil {
+		return m.setErrorf("Could not save create settings: %v", err)
+	}
+	return m
+}
+
+func (m model) persistCreatePreset() error {
+	if m.cfg == nil {
+		m.cfg = config.Default()
+	}
+	elo, err := m.create.elo()
+	if err != nil {
+		return err
+	}
+	m.cfg.Create.SelectedLeafIDs = m.create.selectedLeafIDs()
+	m.cfg.Create.Elo = int(elo)
+	if m.configPath == "" {
+		return nil
+	}
+	return m.cfg.Save(m.configPath)
+}

--- a/app/handle_create.go
+++ b/app/handle_create.go
@@ -22,7 +22,7 @@ func (m model) handleCreateGenerate() (model, tea.Cmd) {
 	}
 
 	leaf := leaves[m.createChoiceIndex(len(leaves))]
-	spawner, modeTitle, err := m.create.resolveLeafMode(leaf, elo)
+	spawner, modeTitle, err := m.create.resolveLeafVariant(leaf, elo)
 	if err != nil {
 		return m.setErrorf("Could not prepare puzzle: %v", err), nil
 	}

--- a/app/handle_create_test.go
+++ b/app/handle_create_test.go
@@ -157,20 +157,15 @@ func createTestState(leaves []createLeaf, elo int) createState {
 func createTestLeaf(id, gameType, modeTitle string) createLeaf {
 	spawner := createTestEloSpawner{}
 	return createLeaf{
-		id:        id,
-		title:     modeTitle,
-		gameType:  gameType,
-		modeTitle: modeTitle,
-		modes: []registry.ModeEntry{{
-			Definition: puzzle.ModeDef{
-				Title:     modeTitle,
-				PresetElo: ptrElo(1200),
+		id:       id,
+		title:    modeTitle,
+		gameType: gameType,
+		variant: registry.VariantEntry{
+			Definition: puzzle.VariantDef{
+				Title:      modeTitle,
+				DefaultElo: 1200,
 			},
 			Elo: spawner,
-		}},
+		},
 	}
-}
-
-func ptrElo(elo difficulty.Elo) *difficulty.Elo {
-	return &elo
 }

--- a/app/handle_create_test.go
+++ b/app/handle_create_test.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"strconv"
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+	"github.com/FelineStateMachine/puzzletea/config"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+	"github.com/FelineStateMachine/puzzletea/puzzle"
+	"github.com/FelineStateMachine/puzzletea/registry"
+	sessionflow "github.com/FelineStateMachine/puzzletea/session"
+	"github.com/FelineStateMachine/puzzletea/store"
+)
+
+type createTestEloSpawner struct{}
+
+func (createTestEloSpawner) SpawnElo(string, difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return &escapeTrackingGame{}, difficulty.Report{
+		TargetElo:  1200,
+		ActualElo:  1200,
+		Confidence: difficulty.ConfidenceHigh,
+	}, nil
+}
+
+func TestCreateGenerateBlocksWithoutSelection(t *testing.T) {
+	m := model{create: createTestState(nil, 1200), store: openAppTestStore(t), cfg: config.Default()}
+
+	got, _ := m.handleCreateGenerate()
+	if got.notice.message == "" {
+		t.Fatal("expected notice for empty selection")
+	}
+}
+
+func TestCreateGenerateUsesSingleSelectedLeafAndSeed(t *testing.T) {
+	s := openAppTestStore(t)
+	state := createTestState([]createLeaf{createTestLeaf("a", "Alpha", "Tiny")}, 1300)
+	state.seedInput.SetValue("daily create seed")
+	m := model{create: state, store: s, cfg: config.Default()}
+
+	got, cmd := m.handleCreateGenerate()
+	if cmd == nil {
+		t.Fatal("expected generation command")
+	}
+	if got.session.spawn == nil {
+		t.Fatal("missing spawn metadata")
+	}
+	if got.session.spawn.gameType != "Alpha" || got.session.spawn.modeTitle != "Tiny" {
+		t.Fatalf("spawn = %#v, want Alpha/Tiny", got.session.spawn)
+	}
+	if got.session.spawn.run.Kind != store.RunKindSeeded {
+		t.Fatalf("run kind = %q, want seeded", got.session.spawn.run.Kind)
+	}
+}
+
+func TestCreateGenerateMultipleSelectionIgnoresSeedAndUsesInjectedRandomChoice(t *testing.T) {
+	s := openAppTestStore(t)
+	state := createTestState([]createLeaf{
+		createTestLeaf("a", "Alpha", "Tiny"),
+		createTestLeaf("b", "Beta", "Large"),
+	}, 1300)
+	state.seedInput.SetValue("ignored")
+	m := model{
+		create: state,
+		store:  s,
+		cfg:    config.Default(),
+		createRandIndex: func(n int) int {
+			if n != 2 {
+				t.Fatalf("random choice bound = %d, want 2", n)
+			}
+			return 1
+		},
+	}
+
+	got, cmd := m.handleCreateGenerate()
+	if cmd == nil {
+		t.Fatal("expected generation command")
+	}
+	if got.session.spawn.gameType != "Beta" {
+		t.Fatalf("spawn gameType = %q, want Beta", got.session.spawn.gameType)
+	}
+	if got.session.spawn.run.Kind != store.RunKindNormal {
+		t.Fatalf("run kind = %q, want normal", got.session.spawn.run.Kind)
+	}
+	if got.session.spawn.run.SeedText != "" {
+		t.Fatalf("seed text = %q, want blank", got.session.spawn.run.SeedText)
+	}
+}
+
+func TestCreateGenerateSeededSingleLeafResumesExistingRecord(t *testing.T) {
+	s := openAppTestStore(t)
+	leaf := createTestLeaf("lights", "Lights Out", "Easy")
+	state := createTestState([]createLeaf{leaf}, 1000)
+	state.seedInput.SetValue("resume create")
+	name := sessionflow.SeededNameForCreateLeaf("resume create", leaf.gameType, leaf.id, 1000)
+	rec := &store.GameRecord{
+		Name:         name,
+		GameType:     "Lights Out",
+		Mode:         "Easy",
+		InitialState: `{"grid":[[true]],"mode_title":"Easy"}`,
+		SaveState:    `{"grid":[[true]],"mode_title":"Easy"}`,
+		Status:       store.StatusAbandoned,
+		RunKind:      store.RunKindSeeded,
+		SeedText:     "resume create",
+	}
+	if err := s.CreateGame(rec); err != nil {
+		t.Fatal(err)
+	}
+	m := model{create: state, store: s, cfg: config.Default()}
+
+	got, cmd := m.handleCreateGenerate()
+	if cmd != nil {
+		t.Fatal("expected resume without generation command")
+	}
+	if got.state != gameView {
+		t.Fatalf("state = %d, want gameView", got.state)
+	}
+	saved, err := s.GetDailyGame(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.Status != store.StatusInProgress {
+		t.Fatalf("status = %q, want in_progress", saved.Status)
+	}
+}
+
+func createTestState(leaves []createLeaf, elo int) createState {
+	eloInput := textinput.New()
+	eloInput.SetValue("1200")
+	if elo > 0 {
+		eloInput.SetValue(strconv.Itoa(elo))
+	}
+	seedInput := textinput.New()
+
+	children := make([]createTreeNode, 0, len(leaves))
+	checked := make(map[string]bool, len(leaves))
+	for _, leaf := range leaves {
+		leaf := leaf
+		children = append(children, createTreeNode{id: leaf.id, title: leaf.title, leaf: &leaf})
+		checked[leaf.id] = true
+	}
+
+	return createState{
+		tree: []createTreeNode{{
+			id:       "group:test",
+			title:    "Test",
+			children: children,
+		}},
+		checked:   checked,
+		expanded:  map[string]bool{"group:test": true},
+		eloInput:  eloInput,
+		seedInput: seedInput,
+	}
+}
+
+func createTestLeaf(id, gameType, modeTitle string) createLeaf {
+	spawner := createTestEloSpawner{}
+	return createLeaf{
+		id:        id,
+		title:     modeTitle,
+		gameType:  gameType,
+		modeTitle: modeTitle,
+		modes: []registry.ModeEntry{{
+			Definition: puzzle.ModeDef{
+				Title:     modeTitle,
+				PresetElo: ptrElo(1200),
+			},
+			Elo: spawner,
+		}},
+	}
+}
+
+func ptrElo(elo difficulty.Elo) *difficulty.Elo {
+	return &elo
+}

--- a/app/mode_display.go
+++ b/app/mode_display.go
@@ -9,22 +9,22 @@ import (
 )
 
 type modeDisplayItem struct {
-	mode        registry.ModeEntry
+	mode        registry.VariantEntry
 	title       string
 	description string
 	filterValue string
 }
 
-func (i modeDisplayItem) Title() string                { return i.title }
-func (i modeDisplayItem) Description() string          { return i.description }
-func (i modeDisplayItem) FilterValue() string          { return i.filterValue }
-func (i modeDisplayItem) Original() registry.ModeEntry { return i.mode }
+func (i modeDisplayItem) Title() string                   { return i.title }
+func (i modeDisplayItem) Description() string             { return i.description }
+func (i modeDisplayItem) FilterValue() string             { return i.filterValue }
+func (i modeDisplayItem) Original() registry.VariantEntry { return i.mode }
 
 func buildModeDisplayItems(entry registry.Entry) []list.Item {
 	titles := modeDisplayTitles(entry)
-	items := make([]list.Item, 0, len(entry.Modes))
+	items := make([]list.Item, 0, len(entry.Variants))
 
-	for idx, mode := range entry.Modes {
+	for idx, mode := range entry.Variants {
 		displayTitle := titles[idx]
 		filterValue := displayTitle + " " + mode.Definition.Description
 		if displayTitle != mode.Definition.Title {
@@ -43,15 +43,15 @@ func buildModeDisplayItems(entry registry.Entry) []list.Item {
 }
 
 func modeDisplayTitles(entry registry.Entry) []string {
-	counts := make(map[string]int, len(entry.Modes))
-	titles := make([]string, 0, len(entry.Modes))
+	counts := make(map[string]int, len(entry.Variants))
+	titles := make([]string, 0, len(entry.Variants))
 
-	for _, mode := range entry.Modes {
+	for _, mode := range entry.Variants {
 		base, _ := trimGridSizeSuffix(mode.Definition.Title)
 		counts[puzzle.NormalizeName(base)]++
 	}
 
-	for _, mode := range entry.Modes {
+	for _, mode := range entry.Variants {
 		title := mode.Definition.Title
 		base, hadSize := trimGridSizeSuffix(title)
 		if hadSize && counts[puzzle.NormalizeName(base)] == 1 {
@@ -64,7 +64,7 @@ func modeDisplayTitles(entry registry.Entry) []string {
 }
 
 func unwrapModeDisplayItem(item list.Item) any {
-	displayItem, ok := item.(interface{ Original() registry.ModeEntry })
+	displayItem, ok := item.(interface{ Original() registry.VariantEntry })
 	if !ok {
 		return item
 	}

--- a/app/mode_display_test.go
+++ b/app/mode_display_test.go
@@ -21,9 +21,9 @@ func TestModeDisplayTitlesStripUniqueGridSizes(t *testing.T) {
 
 	entry := registry.Entry{
 		Definition: puzzle.Definition{Name: "Example"},
-		Modes: []registry.ModeEntry{
-			{Definition: puzzle.ModeDef{Title: "Mini 5x5", Description: "Mini 5x5 description"}},
-			{Definition: puzzle.ModeDef{Title: "Hard 10x10", Description: "Hard 10x10 description"}},
+		Variants: []registry.VariantEntry{
+			{Definition: puzzle.VariantDef{Title: "Mini 5x5", Description: "Mini 5x5 description"}},
+			{Definition: puzzle.VariantDef{Title: "Hard 10x10", Description: "Hard 10x10 description"}},
 		},
 	}
 
@@ -45,10 +45,10 @@ func TestModeDisplayTitlesKeepDuplicateBaseNames(t *testing.T) {
 
 	entry := registry.Entry{
 		Definition: puzzle.Definition{Name: "Example"},
-		Modes: []registry.ModeEntry{
-			{Definition: puzzle.ModeDef{Title: "Easy 5x5", Description: "Easy 5x5 description"}},
-			{Definition: puzzle.ModeDef{Title: "Easy 10x10", Description: "Easy 10x10 description"}},
-			{Definition: puzzle.ModeDef{Title: "Hard 10x10", Description: "Hard 10x10 description"}},
+		Variants: []registry.VariantEntry{
+			{Definition: puzzle.VariantDef{Title: "Easy 5x5", Description: "Easy 5x5 description"}},
+			{Definition: puzzle.VariantDef{Title: "Easy 10x10", Description: "Easy 10x10 description"}},
+			{Definition: puzzle.VariantDef{Title: "Hard 10x10", Description: "Hard 10x10 description"}},
 		},
 	}
 
@@ -71,8 +71,8 @@ func TestBuildModeDisplayItemsPreservesOriginalMode(t *testing.T) {
 	original := newTestMode("Hard 10x10")
 	entry := registry.Entry{
 		Definition: puzzle.Definition{Name: "Example"},
-		Modes: []registry.ModeEntry{{
-			Definition: puzzle.ModeDef{Title: original.Title(), Description: original.Description()},
+		Variants: []registry.VariantEntry{{
+			Definition: puzzle.VariantDef{Title: original.Title(), Description: original.Description()},
 		}},
 	}
 
@@ -89,9 +89,9 @@ func TestBuildModeDisplayItemsPreservesOriginalMode(t *testing.T) {
 		t.Fatalf("display item Title() = %q, want %q", got, "Hard")
 	}
 
-	mode, ok := unwrapModeDisplayItem(items[0]).(registry.ModeEntry)
+	mode, ok := unwrapModeDisplayItem(items[0]).(registry.VariantEntry)
 	if !ok {
-		t.Fatal("unwrapModeDisplayItem() did not return a registry.ModeEntry")
+		t.Fatal("unwrapModeDisplayItem() did not return a registry.VariantEntry")
 	}
 	if got := mode.Definition.Title; got != "Hard 10x10" {
 		t.Fatalf("unwrapped mode Title() = %q, want %q", got, "Hard 10x10")

--- a/app/model.go
+++ b/app/model.go
@@ -44,7 +44,6 @@ const (
 	playMenuActionContinue = "continue"
 	playMenuActionDaily    = "daily"
 	playMenuActionWeekly   = "weekly"
-	playMenuActionSeeded   = "seeded"
 
 	optionsMenuActionTheme  = "theme"
 	optionsMenuActionGuides = "guides"
@@ -68,6 +67,7 @@ const (
 	playMenuView
 	optionsMenuView
 	seedInputView
+	createView
 	gameSelectView
 	modeSelectView
 	exportView
@@ -192,6 +192,7 @@ type model struct {
 	cont    continueState
 	session sessionState
 	seed    seedState
+	create  createState
 	weekly  weeklyState
 	help    helpState
 	stats   statsState
@@ -209,6 +210,8 @@ type model struct {
 	// Config
 	cfg        *config.Config
 	configPath string
+
+	createRandIndex func(int) int
 }
 
 func newSpinner() spinner.Model {
@@ -274,6 +277,5 @@ func buildPlayMenuItems(now time.Time, currentWeeklyIndex int) []ui.MenuItem {
 		{Action: playMenuActionContinue, ItemTitle: "Continue", Desc: "a previously played puzzle"},
 		{Action: playMenuActionDaily, ItemTitle: "Daily", Desc: now.Format("Jan _2 06")},
 		{Action: playMenuActionWeekly, ItemTitle: "Weekly", Desc: "Week " + formatTwoDigits(week) + "-" + strconv.Itoa(year) + " #" + formatWeeklyMenuIndex(currentWeeklyIndex)},
-		{Action: playMenuActionSeeded, ItemTitle: "Seeded", Desc: "enter a specific seed"},
 	}
 }

--- a/app/screen_core.go
+++ b/app/screen_core.go
@@ -3,6 +3,7 @@ package app
 import (
 	"time"
 
+	"github.com/FelineStateMachine/puzzletea/config"
 	"github.com/FelineStateMachine/puzzletea/registry"
 	sessionflow "github.com/FelineStateMachine/puzzletea/session"
 	"github.com/FelineStateMachine/puzzletea/store"
@@ -46,13 +47,17 @@ func (a quitAction) applyToModel(m model) (model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-type openGameSelectAction struct{}
+type openCreateAction struct{}
 
-func (a openGameSelectAction) applyToModel(m model) (model, tea.Cmd) {
-	m.state = gameSelectView
-	m = m.updateCategoryDetailViewport()
+func (a openCreateAction) applyToModel(m model) (model, tea.Cmd) {
+	createCfg := config.CreateConfig{}
+	if m.cfg != nil {
+		createCfg = m.cfg.Create
+	}
+	m.create = newCreateState(createCfg, m.width)
+	m.state = createView
 	m = m.clearNotice()
-	return m.initScreen(gameSelectView), nil
+	return m.initScreen(createView), nil
 }
 
 type openContinueAction struct{}
@@ -80,12 +85,6 @@ type openWeeklyAction struct{}
 
 func (a openWeeklyAction) applyToModel(m model) (model, tea.Cmd) {
 	return m.enterWeeklyView()
-}
-
-type openSeedInputAction struct{}
-
-func (a openSeedInputAction) applyToModel(m model) (model, tea.Cmd) {
-	return m.enterSeedInputView()
 }
 
 type backAction struct {
@@ -125,15 +124,21 @@ type modeSelectEnterAction struct {
 func (a modeSelectEnterAction) applyToModel(m model) (model, tea.Cmd) {
 	m.nav.selectedCategory = a.entry
 	m.nav.selectedModeTitle = a.mode.Definition.Title
-	cmd := newSessionController(&m).startSpawn(a.mode.Spawner, spawnRequest{
+	name := sessionflow.GenerateUniqueName(m.store)
+	request := spawnRequest{
 		source:      spawnSourceNormal,
-		name:        sessionflow.GenerateUniqueName(m.store),
+		name:        name,
 		gameType:    a.entry.Definition.Name,
 		modeTitle:   a.mode.Definition.Title,
 		run:         store.NormalRunMetadata(),
 		returnState: modeSelectView,
 		exitState:   mainMenuView,
-	})
+	}
+	if a.mode.Definition.PresetElo != nil && a.mode.Elo != nil {
+		cmd := newSessionController(&m).startEloSpawn(a.mode.Elo, name, *a.mode.Definition.PresetElo, request)
+		return m, cmd
+	}
+	cmd := newSessionController(&m).startSpawn(a.mode.Spawner, request)
 	return m, cmd
 }
 
@@ -246,6 +251,9 @@ var screenRegistry = map[viewState]screenFactory{
 	},
 	seedInputView: func(m model) screenModel {
 		return seedInputScreen{width: m.width, height: m.height, seed: m.seed}
+	},
+	createView: func(m model) screenModel {
+		return createScreen{width: m.width, height: m.height, create: m.create}
 	},
 	gameSelectView: func(m model) screenModel {
 		return gameSelectScreen{width: m.width, height: m.height, list: m.nav.gameSelectList, detail: m.nav.categoryDetail}

--- a/app/screen_core.go
+++ b/app/screen_core.go
@@ -109,7 +109,7 @@ type gameSelectEnterAction struct {
 
 func (a gameSelectEnterAction) applyToModel(m model) (model, tea.Cmd) {
 	m.nav.selectedCategory = a.entry
-	m.nav.modeSelectList = ui.InitList(buildModeDisplayItems(a.entry), a.entry.Definition.Name+" - Select Mode")
+	m.nav.modeSelectList = ui.InitList(buildModeDisplayItems(a.entry), a.entry.Definition.Name+" - Select Variant")
 	m.nav.modeSelectList.SetSize(min(m.width, 64), min(m.height, ui.ListHeight(m.nav.modeSelectList)))
 	m.state = modeSelectView
 	m = m.initScreen(modeSelectView)
@@ -118,7 +118,7 @@ func (a gameSelectEnterAction) applyToModel(m model) (model, tea.Cmd) {
 
 type modeSelectEnterAction struct {
 	entry registry.Entry
-	mode  registry.ModeEntry
+	mode  registry.VariantEntry
 }
 
 func (a modeSelectEnterAction) applyToModel(m model) (model, tea.Cmd) {
@@ -134,11 +134,11 @@ func (a modeSelectEnterAction) applyToModel(m model) (model, tea.Cmd) {
 		returnState: modeSelectView,
 		exitState:   mainMenuView,
 	}
-	if a.mode.Definition.PresetElo != nil && a.mode.Elo != nil {
-		cmd := newSessionController(&m).startEloSpawn(a.mode.Elo, name, *a.mode.Definition.PresetElo, request)
+	if a.mode.Elo != nil {
+		cmd := newSessionController(&m).startEloSpawn(a.mode.Elo, name, a.mode.Definition.DefaultElo, request)
 		return m, cmd
 	}
-	cmd := newSessionController(&m).startSpawn(a.mode.Spawner, request)
+	cmd := newSessionController(&m).startSpawn(a.mode.Seeded, request)
 	return m, cmd
 }
 

--- a/app/screen_create.go
+++ b/app/screen_create.go
@@ -553,7 +553,7 @@ func renderCreateTreeLine(state createState, item createVisibleNode, cursor bool
 			marker = "[-] "
 		}
 		count := ""
-		if total > 0 {
+		if total > 1 {
 			count = " " + ui.DimItemStyle().Render(strconv.Itoa(selected)+"/"+strconv.Itoa(total))
 		}
 		return cursorText + prefix + marker + node.title + count

--- a/app/screen_create.go
+++ b/app/screen_create.go
@@ -1,0 +1,648 @@
+package app
+
+import (
+	"strconv"
+	"strings"
+
+	sessionflow "github.com/FelineStateMachine/puzzletea/session"
+	"github.com/FelineStateMachine/puzzletea/theme"
+	"github.com/FelineStateMachine/puzzletea/ui"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type createScreen struct {
+	width  int
+	height int
+	create createState
+}
+
+const createFooterHint = "↑/↓ navigate • enter expand/select/generate • space select • tab field • click select/generate • esc back"
+
+type createRect struct {
+	X int
+	Y int
+	W int
+	H int
+}
+
+func (r createRect) contains(x, y int) bool {
+	return x >= r.X && x < r.X+r.W && y >= r.Y && y < r.Y+r.H
+}
+
+type createSettingsRects struct {
+	Elo         createRect
+	Seed        createRect
+	TotalHeight int
+}
+
+type createContentMetrics struct {
+	Width         int
+	Height        int
+	Settings      createSettingsRects
+	Tree          createRect
+	TreeStart     int
+	TreeEnd       int
+	Pool          createRect
+	Summary       createRect
+	SummaryButton createRect
+}
+
+func (s createScreen) Resize(width, height int) screenModel {
+	s.width = width
+	s.height = height
+	contentWidth, _ := createContentBounds(width, height)
+	_, sideWidth := createLayoutWidths(contentWidth)
+	s.create.seedInput.SetWidth(max(10, sideWidth-8))
+	return s
+}
+
+func (s createScreen) Update(msg tea.Msg) (screenModel, tea.Cmd, screenAction) {
+	if clickMsg, ok := msg.(tea.MouseClickMsg); ok {
+		contentWidth, contentHeight := createContentBounds(s.width, s.height)
+		if next, cmd, action, handled := s.handleMouseClick(clickMsg, contentWidth, contentHeight); handled {
+			return next, cmd, action
+		}
+	}
+
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if ok {
+		switch {
+		case key.Matches(keyMsg, rootKeys.Enter):
+			return s.handleEnter()
+		case key.Matches(keyMsg, rootKeys.Escape):
+			return s, nil, createBackAction{create: s.create}
+		case keyMsg.String() == "tab":
+			s.create.focus = s.nextFocus(1)
+			return s.syncFocus()
+		case keyMsg.String() == "shift+tab":
+			s.create.focus = s.nextFocus(-1)
+			return s.syncFocus()
+		case keyMsg.String() == "up" || keyMsg.String() == "k":
+			if s.create.focus == createFocusTree {
+				s.moveCursor(-1)
+				return s, nil, nil
+			}
+		case keyMsg.String() == "down" || keyMsg.String() == "j":
+			if s.create.focus == createFocusTree {
+				s.moveCursor(1)
+				return s, nil, nil
+			}
+		case keyMsg.String() == " " || keyMsg.String() == "space":
+			if s.create.focus == createFocusTree {
+				s.toggleCurrentTreeNode()
+				return s, nil, nil
+			}
+		}
+	}
+
+	return s.updateFocusedInput(msg)
+}
+
+func (s createScreen) handleMouseClick(msg tea.MouseClickMsg, contentWidth, contentHeight int) (screenModel, tea.Cmd, screenAction, bool) {
+	mouse := msg.Mouse()
+	content := createBody(s.create, s.width, s.height)
+	_, _, contentX, contentY := createPanelContentOrigin(s.width, s.height, content)
+	localX := mouse.X - contentX
+	localY := mouse.Y - contentY
+	if localX < 0 || localY < 0 {
+		return s, nil, nil, false
+	}
+
+	metrics := createMetrics(s.create, contentWidth, contentHeight)
+	if metrics.Settings.Elo.contains(localX, localY) {
+		s.create.focus = createFocusElo
+		s.create.eloInput.SetCursor(createFieldCursor(localX, metrics.Settings.Elo, "Elo"))
+		next, cmd, action := s.syncFocus()
+		return next, cmd, action, true
+	}
+	if metrics.Settings.Seed.contains(localX, localY) {
+		if !s.create.seedEnabled() {
+			return s, nil, nil, true
+		}
+		s.create.focus = createFocusSeed
+		s.create.seedInput.SetCursor(createFieldCursor(localX, metrics.Settings.Seed, "Seed"))
+		next, cmd, action := s.syncFocus()
+		return next, cmd, action, true
+	}
+	if metrics.SummaryButton.contains(localX, localY) {
+		s.create.focus = createFocusGenerate
+		next, cmd, action := s.syncFocus()
+		if s.create.selectedCount() == 0 {
+			return next, cmd, action, true
+		}
+		return next, cmd, createGenerateAction{create: s.create}, true
+	}
+	if index, ok := createTreeIndexAt(localX, localY, metrics, s.create); ok {
+		s.create.focus = createFocusTree
+		s.create.cursor = index
+		next, cmd, action := s.syncFocus()
+		nextScreen := next.(createScreen)
+		return nextScreen.handleEnterWithHandled(cmd, action)
+	}
+	return s, nil, nil, false
+}
+
+func (s createScreen) handleEnterWithHandled(cmd tea.Cmd, action screenAction) (screenModel, tea.Cmd, screenAction, bool) {
+	next, enterCmd, enterAction := s.handleEnter()
+	return next, tea.Batch(cmd, enterCmd), firstScreenAction(action, enterAction), true
+}
+
+func firstScreenAction(actions ...screenAction) screenAction {
+	for _, action := range actions {
+		if action != nil {
+			return action
+		}
+	}
+	return nil
+}
+
+func createFieldCursor(localX int, rect createRect, label string) int {
+	labelWidth := lipgloss.Width(label) + 1
+	return max(localX-rect.X-2-labelWidth, 0)
+}
+
+func createPanelContentOrigin(screenWidth, screenHeight int, content string) (panelX, panelY, contentX, contentY int) {
+	panel := ui.Panel("Create", content, createFooterHint)
+	panelWidth := lipgloss.Width(panel)
+	panelHeight := lipgloss.Height(panel)
+	panelX = max((screenWidth-panelWidth)/2, 0)
+	panelY = max((screenHeight-panelHeight)/2, 0)
+
+	frame := ui.PanelFrame()
+	contentX = panelX + frame.GetHorizontalFrameSize()/2
+	contentY = panelY + 1 + 2 + 2
+	return panelX, panelY, contentX, contentY
+}
+
+func (s createScreen) handleEnter() (screenModel, tea.Cmd, screenAction) {
+	if s.create.focus == createFocusGenerate {
+		if s.create.selectedCount() == 0 {
+			return s, nil, nil
+		}
+		return s, nil, createGenerateAction{create: s.create}
+	}
+	if s.create.focus != createFocusTree {
+		return s, nil, nil
+	}
+
+	visible := s.create.visibleNodes()
+	if s.create.cursor < 0 || s.create.cursor >= len(visible) {
+		return s, nil, nil
+	}
+	node := visible[s.create.cursor].node
+	if node.leaf == nil {
+		s.create.expanded[node.id] = !s.create.expanded[node.id]
+		return s, nil, nil
+	}
+	s.toggleLeaf(node)
+	return s, nil, nil
+}
+
+func (s createScreen) nextFocus(delta int) createFocus {
+	focuses := []createFocus{createFocusTree, createFocusElo, createFocusGenerate}
+	if s.create.seedEnabled() {
+		focuses = []createFocus{createFocusTree, createFocusElo, createFocusSeed, createFocusGenerate}
+	}
+
+	current := 0
+	for i, focus := range focuses {
+		if focus == s.create.focus {
+			current = i
+			break
+		}
+	}
+	next := current + delta
+	for next < 0 {
+		next += len(focuses)
+	}
+	return focuses[next%len(focuses)]
+}
+
+func (s createScreen) syncFocus() (screenModel, tea.Cmd, screenAction) {
+	s.create.eloInput.Blur()
+	s.create.seedInput.Blur()
+	switch s.create.focus {
+	case createFocusElo:
+		return s, s.create.eloInput.Focus(), nil
+	case createFocusSeed:
+		if s.create.seedEnabled() {
+			return s, s.create.seedInput.Focus(), nil
+		}
+		s.create.focus = createFocusTree
+		return s, nil, nil
+	case createFocusGenerate:
+		return s, nil, nil
+	default:
+		return s, nil, nil
+	}
+}
+
+func (s createScreen) updateFocusedInput(msg tea.Msg) (screenModel, tea.Cmd, screenAction) {
+	var cmd tea.Cmd
+	switch s.create.focus {
+	case createFocusElo:
+		s.create.eloInput, cmd = s.create.eloInput.Update(msg)
+	case createFocusSeed:
+		if s.create.seedEnabled() {
+			s.create.seedInput, cmd = s.create.seedInput.Update(msg)
+		}
+	}
+	return s, cmd, nil
+}
+
+func (s *createScreen) moveCursor(delta int) {
+	visible := s.create.visibleNodes()
+	if len(visible) == 0 {
+		s.create.cursor = 0
+		return
+	}
+	s.create.cursor += delta
+	if s.create.cursor < 0 {
+		s.create.cursor = len(visible) - 1
+	}
+	if s.create.cursor >= len(visible) {
+		s.create.cursor = 0
+	}
+}
+
+func (s *createScreen) toggleCurrentTreeNode() {
+	visible := s.create.visibleNodes()
+	if s.create.cursor < 0 || s.create.cursor >= len(visible) {
+		return
+	}
+	node := visible[s.create.cursor].node
+	if node.leaf == nil {
+		s.create.toggleDescendantLeaves(node)
+		s.afterCreateSelectionChanged()
+		return
+	}
+	s.toggleLeaf(node)
+}
+
+func (s *createScreen) toggleLeaf(node createTreeNode) {
+	if node.leaf == nil {
+		return
+	}
+	s.create.checked[node.leaf.id] = !s.create.checked[node.leaf.id]
+	s.afterCreateSelectionChanged()
+}
+
+func (s *createScreen) afterCreateSelectionChanged() {
+	if !s.create.seedEnabled() {
+		s.create.seedInput.Blur()
+		if s.create.focus == createFocusSeed {
+			s.create.focus = createFocusTree
+		}
+	}
+}
+
+func (s createScreen) View(notice noticeState) string {
+	return renderPanelView(
+		s.width,
+		s.height,
+		notice,
+		"Create",
+		createBody(s.create, s.width, s.height),
+		createFooterHint,
+	)
+}
+
+func createBody(state createState, width, height int) string {
+	contentWidth, contentHeight := createContentBounds(width, height)
+	treeWidth, sideWidth := createLayoutWidths(contentWidth)
+	settings := createSettingsPanel(state, contentWidth)
+	tree := createTreePanel(state, treeWidth, contentHeight)
+	sidebar := createPoolPanel(state, sideWidth, contentHeight)
+	summary := createSummaryPanel(state, contentWidth)
+
+	var middle string
+	if contentWidth < 88 {
+		middle = lipgloss.JoinVertical(lipgloss.Left, tree, sidebar)
+	} else {
+		middle = lipgloss.JoinHorizontal(lipgloss.Top, tree, "   ", sidebar)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, settings, middle, summary)
+}
+
+func createContentBounds(width, height int) (contentWidth, contentHeight int) {
+	contentWidth = max(width-14, 24)
+	contentHeight = max(height-14, 10)
+	return contentWidth, contentHeight
+}
+
+func createLayoutWidths(contentWidth int) (treeWidth, sideWidth int) {
+	sideWidth = min(42, max(30, contentWidth/3))
+	treeWidth = max(24, contentWidth-sideWidth-3)
+	return treeWidth, sideWidth
+}
+
+func createMetrics(state createState, width, height int) createContentMetrics {
+	settings := createSettingsRectsForWidth(state, width)
+	treeWidth, sideWidth := createLayoutWidths(width)
+	tree := createTreePanel(state, treeWidth, height)
+	pool := createPoolPanel(state, sideWidth, height)
+	summary := createSummaryPanel(state, width)
+	treeHeight := lipgloss.Height(tree)
+	poolHeight := lipgloss.Height(pool)
+	summaryHeight := lipgloss.Height(summary)
+
+	treeY := settings.TotalHeight
+	poolX := 0
+	poolY := treeY + treeHeight
+	if width >= 88 {
+		poolX = treeWidth + 3
+		poolY = treeY
+	}
+	summaryY := settings.TotalHeight + treeHeight + poolHeight
+	if width >= 88 {
+		summaryY = settings.TotalHeight + max(treeHeight, poolHeight)
+	}
+
+	button := renderCreateGenerateChip(state)
+	buttonWidth := lipgloss.Width(button)
+	start, end := createVisibleWindow(state, height)
+	return createContentMetrics{
+		Width:     width,
+		Height:    height,
+		Settings:  settings,
+		Tree:      createRect{X: 0, Y: treeY, W: treeWidth, H: treeHeight},
+		TreeStart: start,
+		TreeEnd:   end,
+		Pool:      createRect{X: poolX, Y: poolY, W: sideWidth, H: poolHeight},
+		Summary:   createRect{X: 0, Y: summaryY, W: width, H: summaryHeight},
+		SummaryButton: createRect{
+			X: max(width-buttonWidth, 0),
+			Y: summaryY,
+			W: buttonWidth,
+			H: summaryHeight,
+		},
+	}
+}
+
+func createSettingsRectsForWidth(state createState, width int) createSettingsRects {
+	inlineHeight := lipgloss.Height(createInlineField("Elo", state.eloInput.View(), state.focus == createFocusElo, max(width, 18)))
+	if width < 52 {
+		return createSettingsRects{
+			Elo:         createRect{X: 0, Y: 0, W: width, H: inlineHeight},
+			Seed:        createRect{X: 0, Y: inlineHeight, W: width, H: inlineHeight},
+			TotalHeight: inlineHeight * 2,
+		}
+	}
+
+	eloWidth := 18
+	seedWidth := max(width-eloWidth-2, 24)
+	return createSettingsRects{
+		Elo:         createRect{X: 0, Y: 0, W: eloWidth, H: inlineHeight},
+		Seed:        createRect{X: eloWidth + 2, Y: 0, W: seedWidth, H: inlineHeight},
+		TotalHeight: inlineHeight,
+	}
+}
+
+func createVisibleWindow(state createState, height int) (start, end int) {
+	visible := state.visibleNodes()
+	if len(visible) == 0 {
+		return 0, 0
+	}
+	maxRows := max(8, height-9)
+	if len(visible) <= maxRows {
+		return 0, len(visible)
+	}
+	start = min(max(0, state.cursor-maxRows+1), len(visible)-maxRows)
+	return start, start + maxRows
+}
+
+func createTreeIndexAt(localX, localY int, metrics createContentMetrics, state createState) (int, bool) {
+	if !metrics.Tree.contains(localX, localY) {
+		return 0, false
+	}
+	row := localY - metrics.Tree.Y - 2
+	if row < 0 || row >= metrics.TreeEnd-metrics.TreeStart {
+		return 0, false
+	}
+	visible := state.visibleNodes()
+	if metrics.TreeStart > 0 && row == 0 {
+		return 0, false
+	}
+	if metrics.TreeEnd < len(visible) && row == metrics.TreeEnd-metrics.TreeStart-1 {
+		return 0, false
+	}
+	index := metrics.TreeStart + row
+	if index < 0 || index >= len(visible) {
+		return 0, false
+	}
+	return index, true
+}
+
+func createTreePanel(state createState, width, height int) string {
+	lines := make([]string, 0)
+	for i, item := range state.visibleNodes() {
+		lines = append(lines, renderCreateTreeLine(state, item, i == state.cursor))
+	}
+	if len(lines) == 0 {
+		lines = append(lines, "No Elo-capable games available.")
+	}
+
+	start, end := createVisibleWindow(state, height)
+	if len(state.visibleNodes()) > 0 && len(lines) > end-start {
+		lines = lines[start:end]
+		if start > 0 {
+			lines[0] = ui.DimItemStyle().Render("...")
+		}
+		if end < len(state.visibleNodes()) {
+			lines[len(lines)-1] = ui.DimItemStyle().Render("...")
+		}
+	}
+
+	return createSection("Puzzle Pool", strings.Join(lines, "\n"), state.focus == createFocusTree, width)
+}
+
+func createSettingsPanel(state createState, width int) string {
+	seed := state.seedInput.View()
+	if !state.seedEnabled() {
+		seed = "disabled for multi-select"
+	}
+
+	if width < 52 {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			createInlineField("Elo", state.eloInput.View(), state.focus == createFocusElo, width),
+			createInlineTextField("Seed", seed, state.focus == createFocusSeed && state.seedEnabled(), !state.seedEnabled(), width),
+		)
+	}
+
+	eloWidth := 18
+	seedWidth := max(width-eloWidth-2, 24)
+	return lipgloss.JoinHorizontal(lipgloss.Top,
+		createInlineField("Elo", state.eloInput.View(), state.focus == createFocusElo, eloWidth),
+		"  ",
+		createInlineTextField("Seed", seed, state.focus == createFocusSeed && state.seedEnabled(), !state.seedEnabled(), seedWidth),
+	)
+}
+
+func createPoolPanel(state createState, width, height int) string {
+	body := lipgloss.JoinVertical(
+		lipgloss.Left,
+		ui.DimItemStyle().Render(strconv.Itoa(state.selectedCount())+" selected"),
+		renderSelectedLeafSummary(state, width-4, max(3, height-7)),
+	)
+	return createSection("Selected", body, false, width)
+}
+
+func createSummaryPanel(state createState, width int) string {
+	totalText := ui.PanelTitle().Render("Total: " + strconv.Itoa(state.selectedCount()))
+	selected := selectedCreateDetail(state)
+	button := renderCreateGenerateChip(state)
+	detailWidth := max(width-lipgloss.Width(totalText)-lipgloss.Width(button)-4, 12)
+	detail := lipgloss.NewStyle().
+		Width(detailWidth).
+		MaxWidth(detailWidth).
+		Render(ui.DimItemStyle().Render(truncatePlainCreateLine(selected, detailWidth)))
+	return lipgloss.JoinHorizontal(lipgloss.Top, totalText, "   ", detail, " ", button)
+}
+
+func renderSelectedLeafSummary(state createState, width, maxRows int) string {
+	leaves := state.selectedLeaves()
+	if len(leaves) == 0 {
+		return ui.DimItemStyle().Render("No leaves selected")
+	}
+
+	limit := min(len(leaves), maxRows)
+	lines := make([]string, 0, limit+1)
+	for _, leaf := range leaves[:limit] {
+		lines = append(lines, ui.DimItemStyle().Render(truncatePlainCreateLine(leaf.gameType+" / "+leaf.title, width)))
+	}
+	if len(leaves) > limit {
+		lines = append(lines, ui.DimItemStyle().Render("+"+strconv.Itoa(len(leaves)-limit)+" more"))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func selectedCreateDetail(state createState) string {
+	leaves := state.selectedLeaves()
+	if len(leaves) == 0 {
+		return "Selected: none"
+	}
+	if len(leaves) == 1 {
+		return "Selected: " + leaves[0].gameType + " / " + leaves[0].title
+	}
+	return "Selected: random from checked pool"
+}
+
+func renderCreateGenerateChip(state createState) string {
+	if state.selectedCount() == 0 {
+		return ui.DimItemStyle().Render(renderChoiceChip("Generate", false))
+	}
+	return renderChoiceChip("Generate", state.focus == createFocusGenerate)
+}
+
+func renderCreateTreeLine(state createState, item createVisibleNode, cursor bool) string {
+	node := item.node
+	prefix := strings.Repeat("  ", item.depth)
+	cursorText := "  "
+	if cursor && state.focus == createFocusTree {
+		cursorText = ui.CursorStyle().Render("> ")
+	}
+	if node.leaf == nil {
+		selected, total := state.descendantLeafCounts(node)
+		marker := "[ ] "
+		if total > 0 && selected == total {
+			marker = "[x] "
+		} else if selected > 0 {
+			marker = "[-] "
+		}
+		count := ""
+		if total > 0 {
+			count = " " + ui.DimItemStyle().Render(strconv.Itoa(selected)+"/"+strconv.Itoa(total))
+		}
+		return cursorText + prefix + marker + node.title + count
+	}
+
+	box := "[ ] "
+	if state.checked[node.leaf.id] {
+		box = "[x] "
+	}
+	return cursorText + prefix + box + node.title
+}
+
+func createInlineField(label, value string, focused bool, width int) string {
+	return createInlineTextField(label, value, focused, false, width)
+}
+
+func createInlineTextField(label, value string, focused, dimmed bool, width int) string {
+	border := theme.Current().Border
+	if focused {
+		border = theme.Current().Accent
+	}
+
+	innerWidth := max(width-4, 1)
+	labelWidth := lipgloss.Width(label) + 1
+	valueStyle := lipgloss.NewStyle().Foreground(theme.Current().FG)
+	if dimmed {
+		valueStyle = ui.DimItemStyle()
+	}
+	if focused {
+		valueStyle = valueStyle.Foreground(theme.Current().Accent).Bold(true)
+	}
+	body := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		ui.DimItemStyle().Render(label),
+		" ",
+		renderSingleLine(valueStyle.Render(value), innerWidth-labelWidth),
+	)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(0, 1).
+		Width(width).
+		Height(1).
+		Render(body)
+}
+
+func createSection(title, content string, focused bool, width int) string {
+	border := theme.Current().Border
+	titleStyle := ui.PanelTitle()
+	if focused {
+		border = theme.Current().Accent
+		titleStyle = ui.SelectedItemStyle()
+	}
+	body := lipgloss.JoinVertical(lipgloss.Left, titleStyle.Render(title), content)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(0, 1).
+		Width(width).
+		Render(body)
+}
+
+func truncatePlainCreateLine(s string, width int) string {
+	if width <= 1 || len(s) <= width {
+		return s
+	}
+	return s[:width-1] + "…"
+}
+
+type createGenerateAction struct {
+	create createState
+}
+
+type createBackAction struct {
+	create createState
+}
+
+func (a createBackAction) applyToModel(m model) (model, tea.Cmd) {
+	m.create = a.create
+	m = m.persistCreatePresetIfValid()
+	m.state = playMenuView
+	return m.resizeActiveScreen(), nil
+}
+
+func (a createGenerateAction) applyToModel(m model) (model, tea.Cmd) {
+	m.create = a.create
+	return m.handleCreateGenerate()
+}
+
+func normalizedCreateSeed(value string) string {
+	return sessionflow.NormalizeSeed(value)
+}

--- a/app/screen_create_test.go
+++ b/app/screen_create_test.go
@@ -210,33 +210,44 @@ func TestCreateScreenMouseClickTreeParentExpands(t *testing.T) {
 
 func TestCreateScreenRenderedParentRowsIncludeRollupCounts(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
+	sudoku := requireCreateNode(t, state.tree, "Sudoku")
+	state.checked[firstDescendantLeafID(t, sudoku.children[0])] = true
+
+	line := renderCreateTreeLine(state, createVisibleNode{node: sudoku}, false)
+	if !strings.Contains(line, "Sudoku") || !strings.Contains(line, "1/2") {
+		t.Fatalf("rendered line = %q, want Sudoku with 1/2 rollup", line)
+	}
+}
+
+func TestCreateScreenRenderedParentRowsHideSingletonRollupCounts(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
-	state.checked[nonogram.children[0].leaf.id] = true
+	state.checked[firstDescendantLeafID(t, nonogram)] = true
 
 	line := renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
-	if !strings.Contains(line, "Nonogram") || !strings.Contains(line, "1/4") {
-		t.Fatalf("rendered line = %q, want Nonogram with 1/4 rollup", line)
+	if strings.Contains(line, "1/1") {
+		t.Fatalf("rendered line = %q, want singleton parent without rollup count", line)
 	}
 }
 
 func TestCreateScreenRenderedParentRowsSignalSelectionState(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
-	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	sudoku := requireCreateNode(t, state.tree, "Sudoku")
 
-	line := renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
-	if !strings.Contains(line, "[ ] Nonogram") {
+	line := renderCreateTreeLine(state, createVisibleNode{node: sudoku}, false)
+	if !strings.Contains(line, "[ ] Sudoku") {
 		t.Fatalf("unchecked parent line = %q, want unchecked marker", line)
 	}
 
-	state.checked[nonogram.children[0].leaf.id] = true
-	line = renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
-	if !strings.Contains(line, "[-] Nonogram") {
+	state.checked[firstDescendantLeafID(t, sudoku.children[0])] = true
+	line = renderCreateTreeLine(state, createVisibleNode{node: sudoku}, false)
+	if !strings.Contains(line, "[-] Sudoku") {
 		t.Fatalf("partial parent line = %q, want partial marker", line)
 	}
 
-	state.toggleDescendantLeaves(nonogram)
-	line = renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
-	if !strings.Contains(line, "[x] Nonogram") {
+	state.toggleDescendantLeaves(sudoku)
+	line = renderCreateTreeLine(state, createVisibleNode{node: sudoku}, false)
+	if !strings.Contains(line, "[x] Sudoku") {
 		t.Fatalf("selected parent line = %q, want checked marker", line)
 	}
 }

--- a/app/screen_create_test.go
+++ b/app/screen_create_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestCreateScreenSpaceTogglesParentDescendantsAndLeaves(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
+	parentIndex := visibleNodeIndexByTitle(t, state, "Sudoku")
+	state.cursor = parentIndex
 	screen := createScreen{create: state}
-	parent := state.visibleNodes()[0].node
+	parent := state.visibleNodes()[parentIndex].node
 	_, parentTotal := state.descendantLeafCounts(parent)
 
 	next, _, _ := screen.Update(tea.KeyPressMsg{Code: tea.KeySpace})
@@ -22,9 +24,8 @@ func TestCreateScreenSpaceTogglesParentDescendantsAndLeaves(t *testing.T) {
 		t.Fatalf("selected count after parent space = %d, want %d", got.create.selectedCount(), parentTotal)
 	}
 
-	next, _, _ = got.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	got = next.(createScreen)
-	got.create.cursor = 1
+	got.create.expanded[parent.id] = true
+	got.create.cursor = visibleLeafIndexByID(t, got.create, firstDescendantLeafID(t, parent.children[0]))
 	next, _, _ = got.Update(tea.KeyPressMsg{Code: tea.KeySpace})
 	got = next.(createScreen)
 	if got.create.selectedCount() != parentTotal-1 {
@@ -33,8 +34,10 @@ func TestCreateScreenSpaceTogglesParentDescendantsAndLeaves(t *testing.T) {
 }
 
 func TestCreateScreenEnterExpandsAndCollapsesParent(t *testing.T) {
-	screen := createScreen{create: newCreateState(config.CreateConfig{}, 80)}
-	parentID := screen.create.visibleNodes()[0].node.id
+	state := newCreateState(config.CreateConfig{}, 80)
+	state.cursor = visibleNodeIndexByTitle(t, state, "Sudoku")
+	screen := createScreen{create: state}
+	parentID := screen.create.visibleNodes()[state.cursor].node.id
 
 	next, _, _ := screen.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	expanded := next.(createScreen)
@@ -53,7 +56,7 @@ func TestCreateScreenEnterExpandsAndCollapsesParent(t *testing.T) {
 }
 
 func TestCreateScreenGenerateButtonProducesAction(t *testing.T) {
-	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 80)
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/nonogram"}}, 80)
 	state.focus = createFocusGenerate
 	screen := createScreen{create: state}
 
@@ -75,7 +78,7 @@ func TestCreateScreenGenerateButtonDisabledWithoutSelection(t *testing.T) {
 }
 
 func TestCreateScreenMouseClickFocusesFields(t *testing.T) {
-	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 120)
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/nonogram"}}, 120)
 	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
 	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
 	metrics := createMetrics(screen.create, contentWidth, contentHeight)
@@ -109,7 +112,7 @@ func TestCreateScreenMouseClickFocusesFields(t *testing.T) {
 
 func TestCreateScreenMouseClickDisabledSeedDoesNotFocusSeed(t *testing.T) {
 	state := newCreateState(config.CreateConfig{
-		SelectedLeafIDs: []string{"nonogram/5x5", "netwalk/5x5"},
+		SelectedLeafIDs: []string{"nonogram/nonogram", "netwalk/netwalk"},
 	}, 120)
 	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
 	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
@@ -130,7 +133,7 @@ func TestCreateScreenMouseClickDisabledSeedDoesNotFocusSeed(t *testing.T) {
 }
 
 func TestCreateScreenMouseClickGenerateButtonProducesAction(t *testing.T) {
-	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 120)
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/nonogram"}}, 120)
 	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
 	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
 	metrics := createMetrics(screen.create, contentWidth, contentHeight)
@@ -189,7 +192,8 @@ func TestCreateScreenMouseClickTreeRowsSelectsAndToggles(t *testing.T) {
 
 func TestCreateScreenMouseClickTreeParentExpands(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 120)
-	parentID := state.visibleNodes()[0].node.id
+	parentIndex := visibleNodeIndexByTitle(t, state, "Sudoku")
+	parentID := state.visibleNodes()[parentIndex].node.id
 	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
 	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
 	metrics := createMetrics(screen.create, contentWidth, contentHeight)
@@ -197,7 +201,7 @@ func TestCreateScreenMouseClickTreeParentExpands(t *testing.T) {
 
 	next, _, _, handled := screen.handleMouseClick(tea.MouseClickMsg{
 		X: contentX + metrics.Tree.X + 4,
-		Y: contentY + metrics.Tree.Y + 2,
+		Y: contentY + metrics.Tree.Y + 2 + parentIndex,
 	}, contentWidth, contentHeight)
 	if !handled {
 		t.Fatal("expected tree parent click to be handled")
@@ -219,14 +223,17 @@ func TestCreateScreenRenderedParentRowsIncludeRollupCounts(t *testing.T) {
 	}
 }
 
-func TestCreateScreenRenderedParentRowsHideSingletonRollupCounts(t *testing.T) {
+func TestCreateScreenRenderedTopLevelLeafOmitsRollupCounts(t *testing.T) {
 	state := newCreateState(config.CreateConfig{}, 80)
 	nonogram := requireCreateNode(t, state.tree, "Nonogram")
 	state.checked[firstDescendantLeafID(t, nonogram)] = true
 
 	line := renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
-	if strings.Contains(line, "1/1") {
-		t.Fatalf("rendered line = %q, want singleton parent without rollup count", line)
+	if strings.Contains(line, "1/1") || strings.Contains(line, "[-]") {
+		t.Fatalf("rendered line = %q, want selected leaf without rollup count", line)
+	}
+	if !strings.Contains(line, "[x] Nonogram") {
+		t.Fatalf("rendered line = %q, want checked top-level leaf", line)
 	}
 }
 
@@ -265,4 +272,26 @@ func TestCreateScreenEloFieldDoesNotRenderPromptMarker(t *testing.T) {
 	if got := state.eloInput.Value(); got != "1200" {
 		t.Fatalf("elo input value = %q, want 1200", got)
 	}
+}
+
+func visibleNodeIndexByTitle(t *testing.T, state createState, title string) int {
+	t.Helper()
+	for i, item := range state.visibleNodes() {
+		if item.node.title == title {
+			return i
+		}
+	}
+	t.Fatalf("missing visible node %q", title)
+	return 0
+}
+
+func visibleLeafIndexByID(t *testing.T, state createState, id string) int {
+	t.Helper()
+	for i, item := range state.visibleNodes() {
+		if item.node.leaf != nil && item.node.leaf.id == id {
+			return i
+		}
+	}
+	t.Fatalf("missing visible leaf %q", id)
+	return 0
 }

--- a/app/screen_create_test.go
+++ b/app/screen_create_test.go
@@ -1,0 +1,257 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/config"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestCreateScreenSpaceTogglesParentDescendantsAndLeaves(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	screen := createScreen{create: state}
+	parent := state.visibleNodes()[0].node
+	_, parentTotal := state.descendantLeafCounts(parent)
+
+	next, _, _ := screen.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	got := next.(createScreen)
+	if got.create.selectedCount() != parentTotal {
+		t.Fatalf("selected count after parent space = %d, want %d", got.create.selectedCount(), parentTotal)
+	}
+
+	next, _, _ = got.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	got = next.(createScreen)
+	got.create.cursor = 1
+	next, _, _ = got.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	got = next.(createScreen)
+	if got.create.selectedCount() != parentTotal-1 {
+		t.Fatalf("selected count after leaf space = %d, want %d", got.create.selectedCount(), parentTotal-1)
+	}
+}
+
+func TestCreateScreenEnterExpandsAndCollapsesParent(t *testing.T) {
+	screen := createScreen{create: newCreateState(config.CreateConfig{}, 80)}
+	parentID := screen.create.visibleNodes()[0].node.id
+
+	next, _, _ := screen.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	expanded := next.(createScreen)
+	if !expanded.create.expanded[parentID] {
+		t.Fatal("expected parent to expand")
+	}
+	if expanded.create.selectedCount() != 0 {
+		t.Fatalf("selected count after parent enter = %d, want 0", expanded.create.selectedCount())
+	}
+
+	next, _, _ = expanded.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	collapsed := next.(createScreen)
+	if collapsed.create.expanded[parentID] {
+		t.Fatal("expected parent to collapse")
+	}
+}
+
+func TestCreateScreenGenerateButtonProducesAction(t *testing.T) {
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 80)
+	state.focus = createFocusGenerate
+	screen := createScreen{create: state}
+
+	_, _, action := screen.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if _, ok := action.(createGenerateAction); !ok {
+		t.Fatalf("action = %T, want createGenerateAction", action)
+	}
+}
+
+func TestCreateScreenGenerateButtonDisabledWithoutSelection(t *testing.T) {
+	state := newCreateState(config.CreateConfig{Elo: 1200}, 80)
+	state.focus = createFocusGenerate
+	screen := createScreen{create: state}
+
+	_, _, action := screen.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if action != nil {
+		t.Fatalf("action = %T, want nil", action)
+	}
+}
+
+func TestCreateScreenMouseClickFocusesFields(t *testing.T) {
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 120)
+	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
+	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
+	metrics := createMetrics(screen.create, contentWidth, contentHeight)
+	_, _, contentX, contentY := createPanelContentOrigin(screen.width, screen.height, createBody(screen.create, screen.width, screen.height))
+
+	next, _, _, handled := screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.Settings.Seed.X + 8,
+		Y: contentY + metrics.Settings.Seed.Y + 1,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected seed field click to be handled")
+	}
+	screen = next.(createScreen)
+	if screen.create.focus != createFocusSeed {
+		t.Fatalf("focus = %v, want createFocusSeed", screen.create.focus)
+	}
+
+	metrics = createMetrics(screen.create, contentWidth, contentHeight)
+	next, _, _, handled = screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.Settings.Elo.X + 7,
+		Y: contentY + metrics.Settings.Elo.Y + 1,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected elo field click to be handled")
+	}
+	screen = next.(createScreen)
+	if screen.create.focus != createFocusElo {
+		t.Fatalf("focus = %v, want createFocusElo", screen.create.focus)
+	}
+}
+
+func TestCreateScreenMouseClickDisabledSeedDoesNotFocusSeed(t *testing.T) {
+	state := newCreateState(config.CreateConfig{
+		SelectedLeafIDs: []string{"nonogram/5x5", "netwalk/5x5"},
+	}, 120)
+	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
+	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
+	metrics := createMetrics(screen.create, contentWidth, contentHeight)
+	_, _, contentX, contentY := createPanelContentOrigin(screen.width, screen.height, createBody(screen.create, screen.width, screen.height))
+
+	next, _, _, handled := screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.Settings.Seed.X + 8,
+		Y: contentY + metrics.Settings.Seed.Y + 1,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected disabled seed field click to be handled")
+	}
+	got := next.(createScreen)
+	if got.create.focus == createFocusSeed {
+		t.Fatal("disabled seed click should not focus the seed input")
+	}
+}
+
+func TestCreateScreenMouseClickGenerateButtonProducesAction(t *testing.T) {
+	state := newCreateState(config.CreateConfig{SelectedLeafIDs: []string{"nonogram/5x5"}}, 120)
+	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
+	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
+	metrics := createMetrics(screen.create, contentWidth, contentHeight)
+	_, _, contentX, contentY := createPanelContentOrigin(screen.width, screen.height, createBody(screen.create, screen.width, screen.height))
+
+	_, _, action, handled := screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.SummaryButton.X + 1,
+		Y: contentY + metrics.SummaryButton.Y,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected generate button click to be handled")
+	}
+	if _, ok := action.(createGenerateAction); !ok {
+		t.Fatalf("action = %T, want createGenerateAction", action)
+	}
+}
+
+func TestCreateScreenMouseClickTreeRowsSelectsAndToggles(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 120)
+	parentID := state.visibleNodes()[0].node.id
+	state.expanded[parentID] = true
+	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
+	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
+	metrics := createMetrics(screen.create, contentWidth, contentHeight)
+	_, _, contentX, contentY := createPanelContentOrigin(screen.width, screen.height, createBody(screen.create, screen.width, screen.height))
+
+	leafIndex := -1
+	for i, item := range screen.create.visibleNodes() {
+		if item.node.leaf != nil {
+			leafIndex = i
+			break
+		}
+	}
+	if leafIndex < 0 {
+		t.Fatal("test setup expected a visible leaf")
+	}
+	row := leafIndex - metrics.TreeStart
+	next, _, _, handled := screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.Tree.X + 4,
+		Y: contentY + metrics.Tree.Y + 2 + row,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected tree leaf click to be handled")
+	}
+	got := next.(createScreen)
+	if got.create.focus != createFocusTree {
+		t.Fatalf("focus = %v, want createFocusTree", got.create.focus)
+	}
+	if got.create.cursor != leafIndex {
+		t.Fatalf("cursor = %d, want %d", got.create.cursor, leafIndex)
+	}
+	if got.create.selectedCount() != 1 {
+		t.Fatalf("selected count = %d, want 1", got.create.selectedCount())
+	}
+}
+
+func TestCreateScreenMouseClickTreeParentExpands(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 120)
+	parentID := state.visibleNodes()[0].node.id
+	screen := createScreen{create: state}.Resize(120, 36).(createScreen)
+	contentWidth, contentHeight := createContentBounds(screen.width, screen.height)
+	metrics := createMetrics(screen.create, contentWidth, contentHeight)
+	_, _, contentX, contentY := createPanelContentOrigin(screen.width, screen.height, createBody(screen.create, screen.width, screen.height))
+
+	next, _, _, handled := screen.handleMouseClick(tea.MouseClickMsg{
+		X: contentX + metrics.Tree.X + 4,
+		Y: contentY + metrics.Tree.Y + 2,
+	}, contentWidth, contentHeight)
+	if !handled {
+		t.Fatal("expected tree parent click to be handled")
+	}
+	got := next.(createScreen)
+	if !got.create.expanded[parentID] {
+		t.Fatal("expected parent click to expand the tree row")
+	}
+}
+
+func TestCreateScreenRenderedParentRowsIncludeRollupCounts(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+	state.checked[nonogram.children[0].leaf.id] = true
+
+	line := renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
+	if !strings.Contains(line, "Nonogram") || !strings.Contains(line, "1/4") {
+		t.Fatalf("rendered line = %q, want Nonogram with 1/4 rollup", line)
+	}
+}
+
+func TestCreateScreenRenderedParentRowsSignalSelectionState(t *testing.T) {
+	state := newCreateState(config.CreateConfig{}, 80)
+	nonogram := requireCreateNode(t, state.tree, "Nonogram")
+
+	line := renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
+	if !strings.Contains(line, "[ ] Nonogram") {
+		t.Fatalf("unchecked parent line = %q, want unchecked marker", line)
+	}
+
+	state.checked[nonogram.children[0].leaf.id] = true
+	line = renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
+	if !strings.Contains(line, "[-] Nonogram") {
+		t.Fatalf("partial parent line = %q, want partial marker", line)
+	}
+
+	state.toggleDescendantLeaves(nonogram)
+	line = renderCreateTreeLine(state, createVisibleNode{node: nonogram}, false)
+	if !strings.Contains(line, "[x] Nonogram") {
+		t.Fatalf("selected parent line = %q, want checked marker", line)
+	}
+}
+
+func TestCreateScreenEloFieldDoesNotRenderPromptMarker(t *testing.T) {
+	state := newCreateState(config.CreateConfig{Elo: 1200}, 80)
+	state.focus = createFocusElo
+	screen, _, _ := (createScreen{create: state}).syncFocus()
+	state = screen.(createScreen).create
+
+	settings := ansi.Strip(createSettingsPanel(state, 80))
+	if strings.Contains(settings, "> 1200") || strings.Contains(settings, ">1200") {
+		t.Fatalf("settings rendered Elo prompt marker: %q", settings)
+	}
+	if got := state.eloInput.Value(); got != "1200" {
+		t.Fatalf("elo input value = %q, want 1200", got)
+	}
+}

--- a/app/screen_menu.go
+++ b/app/screen_menu.go
@@ -69,15 +69,13 @@ func (s playMenuScreen) Update(msg tea.Msg) (screenModel, tea.Cmd, screenAction)
 	case key.Matches(keyMsg, rootKeys.Enter):
 		switch s.menu.SelectedAction() {
 		case playMenuActionCreate:
-			return s, nil, openGameSelectAction{}
+			return s, nil, openCreateAction{}
 		case playMenuActionContinue:
 			return s, nil, openContinueAction{}
 		case playMenuActionDaily:
 			return s, nil, openDailyAction{}
 		case playMenuActionWeekly:
 			return s, nil, openWeeklyAction{}
-		case playMenuActionSeeded:
-			return s, nil, openSeedInputAction{}
 		}
 	case key.Matches(keyMsg, rootKeys.Escape):
 		return s, nil, backAction{target: mainMenuView}

--- a/app/screen_navigation.go
+++ b/app/screen_navigation.go
@@ -142,7 +142,7 @@ func (s modeSelectScreen) Update(msg tea.Msg) (screenModel, tea.Cmd, screenActio
 		switch {
 		case key.Matches(keyMsg, rootKeys.Enter):
 			item := unwrapModeDisplayItem(s.list.SelectedItem())
-			mode, ok := item.(registry.ModeEntry)
+			mode, ok := item.(registry.VariantEntry)
 			if !ok {
 				return s, nil, nil
 			}
@@ -159,7 +159,7 @@ func (s modeSelectScreen) Update(msg tea.Msg) (screenModel, tea.Cmd, screenActio
 
 func (s modeSelectScreen) View(notice noticeState) string {
 	return renderPanelView(s.width, s.height, notice,
-		s.entry.Definition.Name+" — Select Mode",
+		s.entry.Definition.Name+" - Select Variant",
 		s.list.View(),
 		"↑/↓ navigate • enter select • esc back",
 	)

--- a/app/screens_test.go
+++ b/app/screens_test.go
@@ -79,12 +79,12 @@ func TestPlayMenuScreenRoutesByStableAction(t *testing.T) {
 			},
 		},
 		{
-			name: "seeded",
-			item: ui.MenuItem{Action: playMenuActionSeeded, ItemTitle: "Named Seed", Desc: "custom label"},
+			name: "create",
+			item: ui.MenuItem{Action: playMenuActionCreate, ItemTitle: "New", Desc: "custom label"},
 			assert: func(t *testing.T, action screenAction) {
 				t.Helper()
-				if _, ok := action.(openSeedInputAction); !ok {
-					t.Fatalf("action = %T, want %T", action, openSeedInputAction{})
+				if _, ok := action.(openCreateAction); !ok {
+					t.Fatalf("action = %T, want %T", action, openCreateAction{})
 				}
 			},
 		},

--- a/app/seed_input.go
+++ b/app/seed_input.go
@@ -23,18 +23,11 @@ func buildSeedModeOptions(definitions []puzzle.Definition) []seedModeOption {
 			continue
 		}
 
-		for _, mode := range def.Modes {
-			if !mode.Seeded {
-				continue
-			}
-
-			options = append(options, seedModeOption{
-				key:      seedModeKey(def.Name, ""),
-				label:    def.Name,
-				gameType: def.Name,
-			})
-			break
-		}
+		options = append(options, seedModeOption{
+			key:      seedModeKey(def.Name, ""),
+			label:    def.Name,
+			gameType: def.Name,
+		})
 	}
 
 	return options
@@ -48,12 +41,7 @@ func seedModeKey(gameType, modeTitle string) string {
 }
 
 func definitionHasSeededModes(def puzzle.Definition) bool {
-	for _, mode := range def.Modes {
-		if mode.Seeded {
-			return true
-		}
-	}
-	return false
+	return len(def.Variants) > 0
 }
 
 func findSeedModeIndex(options []seedModeOption, key string) int {

--- a/app/session_controller.go
+++ b/app/session_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	sessionflow "github.com/FelineStateMachine/puzzletea/session"
 	"github.com/FelineStateMachine/puzzletea/store"
@@ -48,6 +49,15 @@ func (c sessionController) startSpawn(spawner game.Spawner, request spawnRequest
 	*c.model = c.model.clearNotice()
 	*c.model = c.model.initScreen(generatingView)
 	return tea.Batch(c.model.spinner.Tick, spawnCmd(spawner, ctx, jobID))
+}
+
+func (c sessionController) startEloSpawn(spawner game.EloSpawner, seed string, elo difficulty.Elo, request spawnRequest) tea.Cmd {
+	ctx, jobID := c.beginSpawnContext()
+	c.model.session.spawn = &request
+	c.model.state = generatingView
+	*c.model = c.model.clearNotice()
+	*c.model = c.model.initScreen(generatingView)
+	return tea.Batch(c.model.spinner.Tick, spawnEloCmd(spawner, seed, elo, ctx, jobID))
 }
 
 func (c sessionController) startSeededSpawn(spawner game.SeededSpawner, rng *rand.Rand, request spawnRequest) tea.Cmd {
@@ -95,13 +105,14 @@ func (c sessionController) handleSpawnComplete(jobID int64, msg game.SpawnComple
 	})
 	*c.model = c.model.clearNotice()
 
-	rec, err := sessionflow.CreateRecord(
+	rec, err := sessionflow.CreateRecordWithDifficulty(
 		c.model.store,
 		c.model.session.game,
 		request.name,
 		request.gameType,
 		request.modeTitle,
 		request.run,
+		difficultyMetadataFromSpawnReport(msg.Report),
 	)
 	if err != nil {
 		*c.model = c.model.setErrorf("Started puzzle, but could not create a save record: %v", err)
@@ -109,6 +120,19 @@ func (c sessionController) handleSpawnComplete(jobID int64, msg game.SpawnComple
 		c.model.session.activeGameID = rec.ID
 	}
 	return nil
+}
+
+func difficultyMetadataFromSpawnReport(report difficulty.Report) sessionflow.DifficultyMetadata {
+	if report.Confidence == "" {
+		return sessionflow.DifficultyMetadata{}
+	}
+	target := report.TargetElo
+	actual := report.ActualElo
+	return sessionflow.DifficultyMetadata{
+		TargetElo:  &target,
+		ActualElo:  &actual,
+		Confidence: report.Confidence,
+	}
 }
 
 func (c sessionController) activateGame(g game.Gamer, activeGameID int64, completionSaved bool, options gameOpenOptions) {

--- a/app/spawn.go
+++ b/app/spawn.go
@@ -5,6 +5,7 @@ import (
 	"math/rand/v2"
 	"time"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/store"
 
@@ -16,6 +17,25 @@ const spawnTimeout = 10 * time.Second
 type spawnCompleteMsg struct {
 	jobID  int64
 	result game.SpawnCompleteMsg
+}
+
+func spawnEloCmd(spawner game.EloSpawner, seed string, elo difficulty.Elo, ctx context.Context, jobID int64) tea.Cmd {
+	return func() tea.Msg {
+		var (
+			g      game.Gamer
+			report difficulty.Report
+			err    error
+		)
+		if cancellable, ok := spawner.(game.CancellableEloSpawner); ok {
+			g, report, err = cancellable.SpawnEloContext(ctx, seed, elo)
+		} else {
+			g, report, err = spawner.SpawnElo(seed, elo)
+		}
+		return spawnCompleteMsg{
+			jobID:  jobID,
+			result: game.SpawnCompleteMsg{Game: g, Report: report, Err: err},
+		}
+	}
 }
 
 // spawnCmd returns a tea.Cmd that runs Spawn() off the main goroutine.

--- a/app/view.go
+++ b/app/view.go
@@ -17,7 +17,7 @@ import (
 func (m model) View() tea.View {
 	v := tea.NewView(m.viewContent())
 	v.AltScreen = true
-	if m.state == gameView || m.state == exportView {
+	if m.state == gameView || m.state == createView || m.state == exportView {
 		v.MouseMode = tea.MouseModeCellMotion
 		v.KeyboardEnhancements.ReportEventTypes = true
 	}

--- a/app/view.go
+++ b/app/view.go
@@ -120,22 +120,22 @@ func renderCategoryDetailContent(entry registry.Entry, width int) string {
 		Width(width).
 		Render(entry.Definition.Description)
 
-	meta := ui.DimItemStyle().Render(fmt.Sprintf("%d modes available", len(entry.Modes)))
+	meta := ui.DimItemStyle().Render(fmt.Sprintf("%d variants available", len(entry.Variants)))
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		ui.PanelTitle().Render(entry.Definition.Name),
 		meta,
 		"",
 		desc,
 		"",
-		ui.SelectedItemStyle().Render("Modes"),
+		ui.SelectedItemStyle().Render("Variants"),
 		renderModeList(entry, width),
 	)
 	return content
 }
 
 func renderModeList(entry registry.Entry, width int) string {
-	if len(entry.Modes) == 0 {
-		return ui.DimItemStyle().Render("No modes available.")
+	if len(entry.Variants) == 0 {
+		return ui.DimItemStyle().Render("No variants available.")
 	}
 
 	displayTitles := modeDisplayTitles(entry)

--- a/app/view_test.go
+++ b/app/view_test.go
@@ -24,6 +24,23 @@ func TestGameViewRequestsMouseCellMotion(t *testing.T) {
 	}
 }
 
+func TestCreateViewRequestsMouseCellMotion(t *testing.T) {
+	m := model{
+		state:  createView,
+		width:  100,
+		height: 30,
+	}
+	m = m.initScreen(createView)
+
+	v := m.View()
+	if v.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("MouseMode = %v, want %v", v.MouseMode, tea.MouseModeCellMotion)
+	}
+	if !v.KeyboardEnhancements.ReportEventTypes {
+		t.Fatal("expected keyboard event type reporting to remain enabled")
+	}
+}
+
 func TestPlayMenuViewIncludesNotice(t *testing.T) {
 	m := model{
 		state:  playMenuView,

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -119,6 +119,9 @@ func Validate(definitions []puzzle.Definition) error {
 			if err := difficulty.ValidateElo(alias.PresetElo); err != nil {
 				return fmt.Errorf("game %q legacy mode %q preset Elo is invalid: %w", def.Name, alias.Title, err)
 			}
+			if alias.XPWeight < 1 {
+				return fmt.Errorf("game %q legacy mode %q XP weight must be positive", def.Name, alias.Title)
+			}
 		}
 
 		for _, dailyID := range def.DailyModeIDs {

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -5,6 +5,7 @@ package catalog
 import (
 	"fmt"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
 )
 
@@ -94,6 +95,30 @@ func Validate(definitions []puzzle.Definition) error {
 				return fmt.Errorf("game %q has mode %q with empty id", def.Name, mode.Title)
 			}
 			modeTitles[mode.ID] = struct{}{}
+		}
+		variantIDs := make(map[puzzle.VariantID]struct{}, len(def.Variants))
+		for _, variant := range def.Variants {
+			if variant.ID == "" {
+				return fmt.Errorf("game %q has variant %q with empty id", def.Name, variant.Title)
+			}
+			if err := difficulty.ValidateElo(variant.DefaultElo); err != nil {
+				return fmt.Errorf("game %q variant %q default Elo is invalid: %w", def.Name, variant.Title, err)
+			}
+			if _, exists := variantIDs[variant.ID]; exists {
+				return fmt.Errorf("game %q has duplicate variant %q", def.Name, variant.ID)
+			}
+			variantIDs[variant.ID] = struct{}{}
+		}
+		for _, alias := range def.LegacyModes {
+			if alias.ID == "" {
+				return fmt.Errorf("game %q has legacy mode %q with empty id", def.Name, alias.Title)
+			}
+			if _, ok := variantIDs[alias.TargetVariantID]; !ok {
+				return fmt.Errorf("game %q legacy mode %q targets missing variant %q", def.Name, alias.Title, alias.TargetVariantID)
+			}
+			if err := difficulty.ValidateElo(alias.PresetElo); err != nil {
+				return fmt.Errorf("game %q legacy mode %q preset Elo is invalid: %w", def.Name, alias.Title, err)
+			}
 		}
 
 		for _, dailyID := range def.DailyModeIDs {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -127,6 +127,8 @@ func snapshotCommandGlobals(t *testing.T) func() {
 	prevConfigPath := flagConfigPath
 	prevSetSeed := flagSetSeed
 	prevWithSeed := flagWithSeed
+	prevDifficulty := flagDifficulty
+	prevDifficultySet := flagDifficultySet
 	prevExport := flagExport
 	prevOutput := flagOutput
 	prevExportSpecPath := exportSpecPath
@@ -143,6 +145,8 @@ func snapshotCommandGlobals(t *testing.T) func() {
 		flagConfigPath = prevConfigPath
 		flagSetSeed = prevSetSeed
 		flagWithSeed = prevWithSeed
+		flagDifficulty = prevDifficulty
+		flagDifficultySet = prevDifficultySet
 		flagExport = prevExport
 		flagOutput = prevOutput
 		exportSpecPath = prevExportSpecPath

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -73,7 +73,7 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 		return err
 	}
 
-	mode, err := resolve.ModeEntry(entry, modeArg)
+	selection, err := resolve.VariantEntry(entry, modeArg)
 	if err != nil {
 		return err
 	}
@@ -81,6 +81,9 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 	targetElo, err := difficultyFlag()
 	if err != nil {
 		return err
+	}
+	if targetElo == nil {
+		targetElo = selection.ExplicitElo
 	}
 
 	s, err := openStoreFn(cfg.DBPath)
@@ -91,19 +94,39 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 
 	name := sessionflow.GenerateUniqueName(s)
 
-	g, report, err := spawnFromMode(mode, seed, targetElo, name)
+	g, report, err := spawnFromVariant(selection.Variant, seed, targetElo, name)
 	if err != nil {
 		return fmt.Errorf("failed to spawn game: %w", err)
 	}
 	g = g.SetTitle(name)
 
 	meta := difficultyMetadataFromReport(report)
-	rec, err := sessionflow.CreateRecordWithDifficulty(s, g, name, entry.Definition.Name, mode.Definition.Title, store.NormalRunMetadata(), meta)
+	rec, err := sessionflow.CreateRecordWithDifficulty(s, g, name, entry.Definition.Name, selection.DisplayTitle, store.NormalRunMetadata(), meta)
 	if err != nil {
 		return err
 	}
 
 	return runGameProgramFn(s, cfg, activeConfigPath(), g, rec.ID, false)
+}
+
+func spawnFromVariant(variant registry.VariantEntry, seed string, targetElo *difficulty.Elo, fallbackEloSeed string) (game.Gamer, difficulty.Report, error) {
+	effectiveElo := targetElo
+	if effectiveElo == nil {
+		elo := variant.Definition.DefaultElo
+		effectiveElo = &elo
+	}
+	if variant.Elo == nil {
+		return nil, difficulty.Report{}, fmt.Errorf("variant does not support Elo difficulty")
+	}
+	eloSeed := seed
+	if eloSeed == "" {
+		eloSeed = fallbackEloSeed
+	}
+	g, report, err := variant.Elo.SpawnElo(eloSeed, *effectiveElo)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return g, report, nil
 }
 
 func spawnFromMode(mode registry.ModeEntry, seed string, targetElo *difficulty.Elo, fallbackEloSeed string) (game.Gamer, difficulty.Report, error) {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/FelineStateMachine/puzzletea/config"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/registry"
 	"github.com/FelineStateMachine/puzzletea/resolve"
@@ -15,10 +16,12 @@ import (
 )
 
 var (
-	flagSetSeed  string
-	flagWithSeed string
-	flagExport   int
-	flagOutput   string
+	flagSetSeed       string
+	flagWithSeed      string
+	flagDifficulty    int
+	flagDifficultySet bool
+	flagExport        int
+	flagOutput        string
 )
 
 var newCmd = &cobra.Command{
@@ -29,6 +32,7 @@ var newCmd = &cobra.Command{
 		strings.Join(registry.Names(), "\n  ")),
 	Args: cobra.RangeArgs(0, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		flagDifficultySet = cmd.Flags().Changed("difficulty")
 		if flagOutput != "" || cmd.Flags().Changed("export") {
 			return runNewExport(cmd, args)
 		}
@@ -56,6 +60,7 @@ var newCmd = &cobra.Command{
 func init() {
 	newCmd.Flags().StringVar(&flagSetSeed, "set-seed", "", "seed string for deterministic puzzle selection and generation")
 	newCmd.Flags().StringVar(&flagWithSeed, "with-seed", "", "seed string for deterministic puzzle generation within the selected game/mode")
+	newCmd.Flags().IntVar(&flagDifficulty, "difficulty", -1, "target Elo difficulty for Elo-capable generation (0..3000)")
 	newCmd.Flags().IntVarP(&flagExport, "export", "e", 1, "number of puzzles to export")
 	newCmd.Flags().StringVarP(&flagOutput, "output", "o", "", "write puzzles to a jsonl file (defaults to stdout)")
 }
@@ -68,12 +73,17 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 		return err
 	}
 
-	spawner, modeTitle, err := resolve.Mode(entry, modeArg)
+	mode, err := resolve.ModeEntry(entry, modeArg)
 	if err != nil {
 		return err
 	}
 
-	g, err := spawnFromMode(spawner, seed)
+	targetElo, err := difficultyFlag()
+	if err != nil {
+		return err
+	}
+
+	g, report, err := spawnFromMode(mode, seed, targetElo)
 	if err != nil {
 		return fmt.Errorf("failed to spawn game: %w", err)
 	}
@@ -87,7 +97,8 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 	name := sessionflow.GenerateUniqueName(s)
 	g = g.SetTitle(name)
 
-	rec, err := sessionflow.CreateRecord(s, g, name, entry.Definition.Name, modeTitle, store.NormalRunMetadata())
+	meta := difficultyMetadataFromReport(report)
+	rec, err := sessionflow.CreateRecordWithDifficulty(s, g, name, entry.Definition.Name, mode.Definition.Title, store.NormalRunMetadata(), meta)
 	if err != nil {
 		return err
 	}
@@ -95,16 +106,52 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 	return runGameProgramFn(s, cfg, activeConfigPath(), g, rec.ID, false)
 }
 
-func spawnFromMode(spawner game.Spawner, seed string) (game.Gamer, error) {
-	if seed == "" {
-		return spawner.Spawn()
+func spawnFromMode(mode registry.ModeEntry, seed string, targetElo *difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if targetElo != nil {
+		if mode.Elo == nil {
+			return nil, difficulty.Report{}, fmt.Errorf("mode does not support Elo difficulty")
+		}
+		g, report, err := mode.Elo.SpawnElo(seed, *targetElo)
+		if err != nil {
+			return nil, difficulty.Report{}, err
+		}
+		return g, report, nil
 	}
 
-	seeded, ok := spawner.(game.SeededSpawner)
-	if !ok {
-		return nil, fmt.Errorf("mode does not support deterministic spawning")
+	if seed == "" {
+		g, err := mode.Spawner.Spawn()
+		return g, difficulty.Report{}, err
 	}
-	return seeded.SpawnSeeded(resolve.RNGFromString(seed))
+
+	if mode.Seeded == nil {
+		return nil, difficulty.Report{}, fmt.Errorf("mode does not support deterministic spawning")
+	}
+	g, err := mode.Seeded.SpawnSeeded(resolve.RNGFromString(seed))
+	return g, difficulty.Report{}, err
+}
+
+func difficultyFlag() (*difficulty.Elo, error) {
+	if !flagDifficultySet {
+		return nil, nil
+	}
+	elo := difficulty.Elo(flagDifficulty)
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, err
+	}
+	return &elo, nil
+}
+
+func difficultyMetadataFromReport(report difficulty.Report) sessionflow.DifficultyMetadata {
+	if report.Confidence == "" {
+		return sessionflow.DifficultyMetadata{}
+	}
+	target := report.TargetElo
+	actual := report.ActualElo
+	return sessionflow.DifficultyMetadata{
+		TargetElo:  &target,
+		ActualElo:  &actual,
+		Confidence: report.Confidence,
+	}
 }
 
 // launchSeededGame uses an arbitrary seed string to deterministically select

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -83,11 +83,6 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 		return err
 	}
 
-	g, report, err := spawnFromMode(mode, seed, targetElo)
-	if err != nil {
-		return fmt.Errorf("failed to spawn game: %w", err)
-	}
-
 	s, err := openStoreFn(cfg.DBPath)
 	if err != nil {
 		return err
@@ -95,6 +90,11 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 	defer s.Close()
 
 	name := sessionflow.GenerateUniqueName(s)
+
+	g, report, err := spawnFromMode(mode, seed, targetElo, name)
+	if err != nil {
+		return fmt.Errorf("failed to spawn game: %w", err)
+	}
 	g = g.SetTitle(name)
 
 	meta := difficultyMetadataFromReport(report)
@@ -106,12 +106,21 @@ func launchNewGame(gameArg, modeArg, seed string, cfg *config.Config) error {
 	return runGameProgramFn(s, cfg, activeConfigPath(), g, rec.ID, false)
 }
 
-func spawnFromMode(mode registry.ModeEntry, seed string, targetElo *difficulty.Elo) (game.Gamer, difficulty.Report, error) {
-	if targetElo != nil {
+func spawnFromMode(mode registry.ModeEntry, seed string, targetElo *difficulty.Elo, fallbackEloSeed string) (game.Gamer, difficulty.Report, error) {
+	effectiveElo := targetElo
+	if effectiveElo == nil {
+		effectiveElo = mode.Definition.PresetElo
+	}
+
+	if effectiveElo != nil {
 		if mode.Elo == nil {
 			return nil, difficulty.Report{}, fmt.Errorf("mode does not support Elo difficulty")
 		}
-		g, report, err := mode.Elo.SpawnElo(seed, *targetElo)
+		eloSeed := seed
+		if eloSeed == "" {
+			eloSeed = fallbackEloSeed
+		}
+		g, report, err := mode.Elo.SpawnElo(eloSeed, *effectiveElo)
 		if err != nil {
 			return nil, difficulty.Report{}, err
 		}

--- a/cmd/new_export.go
+++ b/cmd/new_export.go
@@ -23,10 +23,9 @@ import (
 var exportNow = time.Now
 
 type exportModeEntry struct {
-	spawner   game.Spawner
-	elo       game.EloSpawner
-	presetElo *difficulty.Elo
-	mode      string
+	elo        game.EloSpawner
+	defaultElo difficulty.Elo
+	mode       string
 }
 
 func runNewExport(cmd *cobra.Command, args []string) error {
@@ -94,32 +93,34 @@ func validateNewExportFlags(_ *cobra.Command, args []string) error {
 
 func collectExportModes(entry registry.Entry, modeArg string) ([]exportModeEntry, string, error) {
 	if modeArg != "" {
-		mode, err := resolve.ModeEntry(entry, modeArg)
+		selection, err := resolve.VariantEntry(entry, modeArg)
 		if err != nil {
 			return nil, "", err
 		}
+		defaultElo := selection.Variant.Definition.DefaultElo
+		if selection.ExplicitElo != nil {
+			defaultElo = *selection.ExplicitElo
+		}
 		return []exportModeEntry{{
-			spawner:   mode.Spawner,
-			elo:       mode.Elo,
-			presetElo: mode.Definition.PresetElo,
-			mode:      mode.Definition.Title,
-		}}, mode.Definition.Title, nil
+			elo:        selection.Variant.Elo,
+			defaultElo: defaultElo,
+			mode:       selection.Variant.Definition.Title,
+		}}, selection.Variant.Definition.Title, nil
 	}
 
-	entries := make([]exportModeEntry, 0, len(entry.Modes))
-	for _, mode := range entry.Modes {
+	entries := make([]exportModeEntry, 0, len(entry.Variants))
+	for _, variant := range entry.Variants {
 		entries = append(entries, exportModeEntry{
-			spawner:   mode.Spawner,
-			elo:       mode.Elo,
-			presetElo: mode.Definition.PresetElo,
-			mode:      mode.Definition.Title,
+			elo:        variant.Elo,
+			defaultElo: variant.Definition.DefaultElo,
+			mode:       variant.Definition.Title,
 		})
 	}
 	if len(entries) == 0 {
-		return nil, "", fmt.Errorf("game %q has no exportable modes", entry.Definition.Name)
+		return nil, "", fmt.Errorf("game %q has no exportable variants", entry.Definition.Name)
 	}
 
-	return entries, "mixed modes", nil
+	return entries, "mixed variants", nil
 }
 
 func buildExportRecords(
@@ -169,7 +170,7 @@ func buildExportRecords(
 		}
 
 		records = append(records, pdfexport.JSONLRecord{
-			Schema: pdfexport.ExportSchemaV1,
+			Schema: pdfexport.ExportSchemaV2,
 			Pack: pdfexport.JSONLPackMeta{
 				Generated:     generatedAt.Format(time.RFC3339),
 				Version:       Version,
@@ -205,31 +206,19 @@ func scopedExportEloSeed(seed string, generatedAt time.Time, gameType, mode stri
 func spawnExportPuzzle(entry exportModeEntry, rng *rand.Rand, seed string, targetElo *difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	effectiveElo := targetElo
 	if effectiveElo == nil {
-		effectiveElo = entry.presetElo
+		effectiveElo = &entry.defaultElo
 	}
-
-	if effectiveElo != nil {
-		if entry.elo == nil {
-			return nil, difficulty.Report{}, fmt.Errorf("mode does not support Elo difficulty")
-		}
-		g, report, err := entry.elo.SpawnElo(seed, *effectiveElo)
-		if err != nil {
-			return nil, difficulty.Report{}, err
-		}
-		return g, report, nil
+	if entry.elo == nil {
+		return nil, difficulty.Report{}, fmt.Errorf("variant does not support Elo difficulty")
 	}
-
-	if rng == nil {
-		g, err := entry.spawner.Spawn()
-		return g, difficulty.Report{}, err
+	if rng != nil && strings.TrimSpace(seed) == "" {
+		seed = fmt.Sprintf("export-seeded:%016x:%016x", rng.Uint64(), rng.Uint64())
 	}
-
-	seeded, ok := entry.spawner.(game.SeededSpawner)
-	if !ok {
-		return nil, difficulty.Report{}, fmt.Errorf("mode does not support deterministic spawning")
+	g, report, err := entry.elo.SpawnElo(seed, *effectiveElo)
+	if err != nil {
+		return nil, difficulty.Report{}, err
 	}
-	g, err := seeded.SpawnSeeded(rng)
-	return g, difficulty.Report{}, err
+	return g, report, nil
 }
 
 func intPtrFromEloReport(elo difficulty.Elo, confidence difficulty.Confidence) *int {

--- a/cmd/new_export.go
+++ b/cmd/new_export.go
@@ -23,9 +23,10 @@ import (
 var exportNow = time.Now
 
 type exportModeEntry struct {
-	spawner game.Spawner
-	elo     game.EloSpawner
-	mode    string
+	spawner   game.Spawner
+	elo       game.EloSpawner
+	presetElo *difficulty.Elo
+	mode      string
 }
 
 func runNewExport(cmd *cobra.Command, args []string) error {
@@ -97,15 +98,21 @@ func collectExportModes(entry registry.Entry, modeArg string) ([]exportModeEntry
 		if err != nil {
 			return nil, "", err
 		}
-		return []exportModeEntry{{spawner: mode.Spawner, elo: mode.Elo, mode: mode.Definition.Title}}, mode.Definition.Title, nil
+		return []exportModeEntry{{
+			spawner:   mode.Spawner,
+			elo:       mode.Elo,
+			presetElo: mode.Definition.PresetElo,
+			mode:      mode.Definition.Title,
+		}}, mode.Definition.Title, nil
 	}
 
 	entries := make([]exportModeEntry, 0, len(entry.Modes))
 	for _, mode := range entry.Modes {
 		entries = append(entries, exportModeEntry{
-			spawner: mode.Spawner,
-			elo:     mode.Elo,
-			mode:    mode.Definition.Title,
+			spawner:   mode.Spawner,
+			elo:       mode.Elo,
+			presetElo: mode.Definition.PresetElo,
+			mode:      mode.Definition.Title,
 		})
 	}
 	if len(entries) == 0 {
@@ -196,11 +203,16 @@ func scopedExportEloSeed(seed string, generatedAt time.Time, gameType, mode stri
 }
 
 func spawnExportPuzzle(entry exportModeEntry, rng *rand.Rand, seed string, targetElo *difficulty.Elo) (game.Gamer, difficulty.Report, error) {
-	if targetElo != nil {
+	effectiveElo := targetElo
+	if effectiveElo == nil {
+		effectiveElo = entry.presetElo
+	}
+
+	if effectiveElo != nil {
 		if entry.elo == nil {
 			return nil, difficulty.Report{}, fmt.Errorf("mode does not support Elo difficulty")
 		}
-		g, report, err := entry.elo.SpawnElo(seed, *targetElo)
+		g, report, err := entry.elo.SpawnElo(seed, *effectiveElo)
 		if err != nil {
 			return nil, difficulty.Report{}, err
 		}

--- a/cmd/new_export.go
+++ b/cmd/new_export.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/export/builtinprint"
 	"github.com/FelineStateMachine/puzzletea/export/pack"
 	"github.com/FelineStateMachine/puzzletea/export/pdf"
@@ -23,11 +24,13 @@ var exportNow = time.Now
 
 type exportModeEntry struct {
 	spawner game.Spawner
+	elo     game.EloSpawner
 	mode    string
 }
 
 func runNewExport(cmd *cobra.Command, args []string) error {
 	builtinprint.Register()
+	flagDifficultySet = cmd.Flags().Changed("difficulty")
 
 	if err := validateNewExportFlags(cmd, args); err != nil {
 		return err
@@ -51,8 +54,13 @@ func runNewExport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	targetElo, err := difficultyFlag()
+	if err != nil {
+		return err
+	}
+
 	generatedAt := exportNow()
-	records, err := buildExportRecords(entry.Definition.Name, modeSelection, entries, flagExport, flagWithSeed, generatedAt)
+	records, err := buildExportRecords(entry.Definition.Name, modeSelection, entries, flagExport, flagWithSeed, targetElo, generatedAt)
 	if err != nil {
 		return err
 	}
@@ -85,17 +93,18 @@ func validateNewExportFlags(_ *cobra.Command, args []string) error {
 
 func collectExportModes(entry registry.Entry, modeArg string) ([]exportModeEntry, string, error) {
 	if modeArg != "" {
-		spawner, modeTitle, err := resolve.Mode(entry, modeArg)
+		mode, err := resolve.ModeEntry(entry, modeArg)
 		if err != nil {
 			return nil, "", err
 		}
-		return []exportModeEntry{{spawner: spawner, mode: modeTitle}}, modeTitle, nil
+		return []exportModeEntry{{spawner: mode.Spawner, elo: mode.Elo, mode: mode.Definition.Title}}, mode.Definition.Title, nil
 	}
 
 	entries := make([]exportModeEntry, 0, len(entry.Modes))
 	for _, mode := range entry.Modes {
 		entries = append(entries, exportModeEntry{
 			spawner: mode.Spawner,
+			elo:     mode.Elo,
 			mode:    mode.Definition.Title,
 		})
 	}
@@ -111,6 +120,7 @@ func buildExportRecords(
 	entries []exportModeEntry,
 	count int,
 	seed string,
+	targetElo *difficulty.Elo,
 	generatedAt time.Time,
 ) ([]pdfexport.JSONLRecord, error) {
 	var rng *rand.Rand
@@ -137,7 +147,8 @@ func buildExportRecords(
 			entry = entries[modeIndex]
 		}
 
-		puzzle, err := spawnExportPuzzle(entry.spawner, rng)
+		eloSeed := scopedExportEloSeed(seed, generatedAt, gameType, entry.mode, i+1)
+		puzzle, report, err := spawnExportPuzzle(entry, rng, eloSeed, targetElo)
 		if err != nil {
 			return nil, fmt.Errorf("generate puzzle %d: %w", i+1, err)
 		}
@@ -161,11 +172,14 @@ func buildExportRecords(
 				Seed:          seed,
 			},
 			Puzzle: pdfexport.JSONLPuzzle{
-				Index: i + 1,
-				Name:  namegen.GenerateSeeded(nameRNG),
-				Game:  gameType,
-				Mode:  entry.mode,
-				Save:  json.RawMessage(save),
+				Index:                i + 1,
+				Name:                 namegen.GenerateSeeded(nameRNG),
+				Game:                 gameType,
+				Mode:                 entry.mode,
+				TargetDifficultyElo:  intPtrFromEloReport(report.TargetElo, report.Confidence),
+				ActualDifficultyElo:  intPtrFromEloReport(report.ActualElo, report.Confidence),
+				DifficultyConfidence: string(report.Confidence),
+				Save:                 json.RawMessage(save),
 			},
 		})
 	}
@@ -173,16 +187,45 @@ func buildExportRecords(
 	return records, nil
 }
 
-func spawnExportPuzzle(spawner game.Spawner, rng *rand.Rand) (game.Gamer, error) {
-	if rng == nil {
-		return spawner.Spawn()
+func scopedExportEloSeed(seed string, generatedAt time.Time, gameType, mode string, index int) string {
+	base := strings.TrimSpace(seed)
+	if base == "" {
+		base = generatedAt.Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("export:%s:%s:%s:%d", base, gameType, mode, index)
+}
+
+func spawnExportPuzzle(entry exportModeEntry, rng *rand.Rand, seed string, targetElo *difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if targetElo != nil {
+		if entry.elo == nil {
+			return nil, difficulty.Report{}, fmt.Errorf("mode does not support Elo difficulty")
+		}
+		g, report, err := entry.elo.SpawnElo(seed, *targetElo)
+		if err != nil {
+			return nil, difficulty.Report{}, err
+		}
+		return g, report, nil
 	}
 
-	seeded, ok := spawner.(game.SeededSpawner)
-	if !ok {
-		return nil, fmt.Errorf("mode does not support deterministic spawning")
+	if rng == nil {
+		g, err := entry.spawner.Spawn()
+		return g, difficulty.Report{}, err
 	}
-	return seeded.SpawnSeeded(rng)
+
+	seeded, ok := entry.spawner.(game.SeededSpawner)
+	if !ok {
+		return nil, difficulty.Report{}, fmt.Errorf("mode does not support deterministic spawning")
+	}
+	g, err := seeded.SpawnSeeded(rng)
+	return g, difficulty.Report{}, err
+}
+
+func intPtrFromEloReport(elo difficulty.Elo, confidence difficulty.Confidence) *int {
+	if confidence == "" {
+		return nil
+	}
+	v := int(elo)
+	return &v
 }
 
 func writeExportJSONL(cmd *cobra.Command, path string, records []pdfexport.JSONLRecord) error {

--- a/cmd/new_export_test.go
+++ b/cmd/new_export_test.go
@@ -192,17 +192,23 @@ func withExportFlagReset(t *testing.T) {
 
 	prevSetSeed := flagSetSeed
 	prevWithSeed := flagWithSeed
+	prevDifficulty := flagDifficulty
+	prevDifficultySet := flagDifficultySet
 	prevExport := flagExport
 	prevOutput := flagOutput
 
 	flagSetSeed = ""
 	flagWithSeed = ""
+	flagDifficulty = -1
+	flagDifficultySet = false
 	flagExport = 1
 	flagOutput = ""
 
 	t.Cleanup(func() {
 		flagSetSeed = prevSetSeed
 		flagWithSeed = prevWithSeed
+		flagDifficulty = prevDifficulty
+		flagDifficultySet = prevDifficultySet
 		flagExport = prevExport
 		flagOutput = prevOutput
 	})

--- a/cmd/new_export_test.go
+++ b/cmd/new_export_test.go
@@ -53,8 +53,8 @@ func TestRunNewExportValidation(t *testing.T) {
 			if err := json.Unmarshal([]byte(line), &record); err != nil {
 				t.Fatalf("line %d is not valid jsonl: %v", i+1, err)
 			}
-			if record.Schema != pdfexport.ExportSchemaV1 {
-				t.Fatalf("line %d schema = %q, want %q", i+1, record.Schema, pdfexport.ExportSchemaV1)
+			if record.Schema != pdfexport.ExportSchemaV2 {
+				t.Fatalf("line %d schema = %q, want %q", i+1, record.Schema, pdfexport.ExportSchemaV2)
 			}
 		}
 	})
@@ -151,7 +151,7 @@ func TestRunNewExportOverwritesOutputFile(t *testing.T) {
 	if string(data) == "old" {
 		t.Fatal("expected output file to be overwritten")
 	}
-	if !strings.Contains(string(data), pdfexport.ExportSchemaV1) {
+	if !strings.Contains(string(data), pdfexport.ExportSchemaV2) {
 		t.Fatal("expected jsonl export schema marker")
 	}
 }

--- a/cmd/new_export_test.go
+++ b/cmd/new_export_test.go
@@ -187,6 +187,54 @@ func TestRunNewExportOmitsPrintPayload(t *testing.T) {
 	}
 }
 
+func TestRunNewExportUsesPresetEloMetadata(t *testing.T) {
+	withExportFlagReset(t)
+	flagExport = 1
+
+	cmd, out := newExportTestCmd(t, true)
+	if err := runNewExport(cmd, []string{"sudoku", "easy"}); err != nil {
+		t.Fatalf("expected sudoku export success, got error: %v", err)
+	}
+
+	record := decodeSingleExportRecord(t, out.String())
+	if record.Puzzle.TargetDifficultyElo == nil {
+		t.Fatal("expected target_difficulty_elo from preset")
+	}
+	if got, want := *record.Puzzle.TargetDifficultyElo, 600; got != want {
+		t.Fatalf("target_difficulty_elo = %d, want %d", got, want)
+	}
+	if record.Puzzle.ActualDifficultyElo == nil {
+		t.Fatal("expected actual_difficulty_elo from Elo report")
+	}
+	if record.Puzzle.DifficultyConfidence == "" {
+		t.Fatal("expected difficulty_confidence")
+	}
+}
+
+func TestRunNewExportExplicitDifficultyOverridesPreset(t *testing.T) {
+	withExportFlagReset(t)
+	flagExport = 1
+	flagDifficulty = 2100
+
+	cmd, out := newExportTestCmd(t, true)
+	cmd.Flags().Int("difficulty", -1, "")
+	if err := cmd.Flags().Set("difficulty", strconv.Itoa(flagDifficulty)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runNewExport(cmd, []string{"sudoku", "easy"}); err != nil {
+		t.Fatalf("expected sudoku export success, got error: %v", err)
+	}
+
+	record := decodeSingleExportRecord(t, out.String())
+	if record.Puzzle.TargetDifficultyElo == nil {
+		t.Fatal("expected target_difficulty_elo from explicit difficulty")
+	}
+	if got, want := *record.Puzzle.TargetDifficultyElo, flagDifficulty; got != want {
+		t.Fatalf("target_difficulty_elo = %d, want %d", got, want)
+	}
+}
+
 func withExportFlagReset(t *testing.T) {
 	t.Helper()
 
@@ -212,6 +260,21 @@ func withExportFlagReset(t *testing.T) {
 		flagExport = prevExport
 		flagOutput = prevOutput
 	})
+}
+
+func decodeSingleExportRecord(t *testing.T, output string) pdfexport.JSONLRecord {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("jsonl lines = %d, want 1", len(lines))
+	}
+
+	var record pdfexport.JSONLRecord
+	if err := json.Unmarshal([]byte(lines[0]), &record); err != nil {
+		t.Fatal(err)
+	}
+	return record
 }
 
 func newExportTestCmd(t *testing.T, exportChanged bool) (*cobra.Command, *bytes.Buffer) {

--- a/cmd/new_spawn_test.go
+++ b/cmd/new_spawn_test.go
@@ -83,6 +83,49 @@ func TestSpawnFromModeUsesPresetEloWhenDifficultyOmitted(t *testing.T) {
 	}
 }
 
+func TestSpawnFromVariantUsesDefaultEloWhenDifficultyOmitted(t *testing.T) {
+	defaultElo := difficulty.Elo(1200)
+	spawner := &testEloSpawner{}
+	variant := registry.VariantEntry{
+		Definition: puzzle.VariantDef{Title: "Rule", DefaultElo: defaultElo},
+		Elo:        spawner,
+	}
+
+	_, report, err := spawnFromVariant(variant, "", nil, "generated-name")
+	if err != nil {
+		t.Fatalf("spawnFromVariant returned error: %v", err)
+	}
+	if !spawner.called {
+		t.Fatal("expected SpawnElo to be called")
+	}
+	if spawner.seed != "generated-name" {
+		t.Fatalf("Elo seed = %q, want generated save name", spawner.seed)
+	}
+	if spawner.elo != defaultElo || report.TargetElo != defaultElo || report.Confidence == "" {
+		t.Fatalf("Elo/report = (%d, %#v), want default report", spawner.elo, report)
+	}
+}
+
+func TestSpawnFromVariantExplicitDifficultyOverridesDefault(t *testing.T) {
+	explicit := difficulty.Elo(2200)
+	spawner := &testEloSpawner{}
+	variant := registry.VariantEntry{
+		Definition: puzzle.VariantDef{Title: "Rule", DefaultElo: 800},
+		Elo:        spawner,
+	}
+
+	_, _, err := spawnFromVariant(variant, "user-seed", &explicit, "generated-name")
+	if err != nil {
+		t.Fatalf("spawnFromVariant returned error: %v", err)
+	}
+	if spawner.elo != explicit {
+		t.Fatalf("Elo = %d, want explicit %d", spawner.elo, explicit)
+	}
+	if spawner.seed != "user-seed" {
+		t.Fatalf("seed = %q, want explicit seed", spawner.seed)
+	}
+}
+
 func TestSpawnFromModeExplicitDifficultyOverridesPreset(t *testing.T) {
 	preset := difficulty.Elo(800)
 	explicit := difficulty.Elo(2200)

--- a/cmd/new_spawn_test.go
+++ b/cmd/new_spawn_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+	"github.com/FelineStateMachine/puzzletea/puzzle"
+	"github.com/FelineStateMachine/puzzletea/registry"
+)
+
+type testSpawnGamer struct{}
+
+func (testSpawnGamer) GetDebugInfo() string                 { return "" }
+func (testSpawnGamer) GetFullHelp() [][]key.Binding         { return nil }
+func (testSpawnGamer) GetSave() ([]byte, error)             { return []byte(`{}`), nil }
+func (testSpawnGamer) IsSolved() bool                       { return false }
+func (testSpawnGamer) Reset() game.Gamer                    { return testSpawnGamer{} }
+func (testSpawnGamer) SetTitle(string) game.Gamer           { return testSpawnGamer{} }
+func (testSpawnGamer) Init() tea.Cmd                        { return nil }
+func (testSpawnGamer) View() string                         { return "" }
+func (testSpawnGamer) Update(tea.Msg) (game.Gamer, tea.Cmd) { return testSpawnGamer{}, nil }
+
+type testLegacySpawner struct {
+	spawned      bool
+	seeded       bool
+	seededCalled bool
+}
+
+func (s *testLegacySpawner) Spawn() (game.Gamer, error) {
+	s.spawned = true
+	return testSpawnGamer{}, nil
+}
+
+func (s *testLegacySpawner) SpawnSeeded(*rand.Rand) (game.Gamer, error) {
+	s.seeded = true
+	s.seededCalled = true
+	return testSpawnGamer{}, nil
+}
+
+type testEloSpawner struct {
+	testLegacySpawner
+	called bool
+	seed   string
+	elo    difficulty.Elo
+}
+
+func (s *testEloSpawner) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	s.called = true
+	s.seed = seed
+	s.elo = elo
+	return testSpawnGamer{}, difficulty.Report{
+		TargetElo:  elo,
+		ActualElo:  elo,
+		Confidence: difficulty.ConfidenceHigh,
+	}, nil
+}
+
+func TestSpawnFromModeUsesPresetEloWhenDifficultyOmitted(t *testing.T) {
+	preset := difficulty.Elo(1200)
+	spawner := &testEloSpawner{}
+	mode := registry.ModeEntry{
+		Definition: puzzle.ModeDef{Title: "Preset", PresetElo: &preset},
+		Spawner:    spawner,
+		Elo:        spawner,
+	}
+
+	_, report, err := spawnFromMode(mode, "", nil, "generated-name")
+	if err != nil {
+		t.Fatalf("spawnFromMode returned error: %v", err)
+	}
+	if !spawner.called {
+		t.Fatal("expected SpawnElo to be called")
+	}
+	if spawner.seed != "generated-name" {
+		t.Fatalf("Elo seed = %q, want generated save name", spawner.seed)
+	}
+	if spawner.elo != preset || report.TargetElo != preset || report.Confidence == "" {
+		t.Fatalf("Elo/report = (%d, %#v), want preset report", spawner.elo, report)
+	}
+}
+
+func TestSpawnFromModeExplicitDifficultyOverridesPreset(t *testing.T) {
+	preset := difficulty.Elo(800)
+	explicit := difficulty.Elo(2200)
+	spawner := &testEloSpawner{}
+	mode := registry.ModeEntry{
+		Definition: puzzle.ModeDef{Title: "Preset", PresetElo: &preset},
+		Spawner:    spawner,
+		Elo:        spawner,
+	}
+
+	_, _, err := spawnFromMode(mode, "user-seed", &explicit, "generated-name")
+	if err != nil {
+		t.Fatalf("spawnFromMode returned error: %v", err)
+	}
+	if spawner.elo != explicit {
+		t.Fatalf("Elo = %d, want explicit %d", spawner.elo, explicit)
+	}
+	if spawner.seed != "user-seed" {
+		t.Fatalf("seed = %q, want explicit seed", spawner.seed)
+	}
+}
+
+func TestSpawnFromModeFallsBackWithoutElo(t *testing.T) {
+	spawner := &testLegacySpawner{}
+	mode := registry.ModeEntry{
+		Definition: puzzle.ModeDef{Title: "Legacy"},
+		Spawner:    spawner,
+		Seeded:     spawner,
+	}
+
+	if _, _, err := spawnFromMode(mode, "", nil, "generated-name"); err != nil {
+		t.Fatalf("random spawnFromMode returned error: %v", err)
+	}
+	if !spawner.spawned {
+		t.Fatal("expected legacy Spawn to be called")
+	}
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -82,7 +82,7 @@ func loadTestRecords(path string) ([]testInputRecord, error) {
 		if err := json.Unmarshal([]byte(line), &record); err != nil {
 			return nil, fmt.Errorf("%s:%d: decode jsonl record: %w", path, lineNo, err)
 		}
-		if record.Schema != pdfexport.ExportSchemaV1 {
+		if !pdfexport.IsSupportedExportSchema(record.Schema) {
 			return nil, fmt.Errorf("%s:%d: unsupported schema %q", path, lineNo, record.Schema)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,13 @@ type Config struct {
 	Theme  string       `json:"theme,omitempty"`   // theme name; empty = default
 	DBPath string       `json:"db_path,omitempty"` // database path; empty = ~/.puzzletea/history.db
 	Export ExportConfig `json:"export,omitempty"`  // last-used export settings
+	Create CreateConfig `json:"create,omitempty"`  // last-used create settings
+}
+
+// CreateConfig stores the app's last-used Create form values.
+type CreateConfig struct {
+	SelectedLeafIDs []string `json:"selected_leaf_ids,omitempty"`
+	Elo             int      `json:"elo,omitempty"`
 }
 
 // ExportConfig stores the app's last-used export form values.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,6 +77,32 @@ func TestSaveAndLoadExportConfig(t *testing.T) {
 	}
 }
 
+func TestSaveAndLoadCreateConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := &Config{
+		Create: CreateConfig{
+			SelectedLeafIDs: []string{"nonogram/5x5", "takuzu/takuzu/6x6"},
+			Elo:             1400,
+		},
+	}
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.Create.Elo != 1400 {
+		t.Fatalf("loaded create Elo = %d, want 1400", loaded.Create.Elo)
+	}
+	if len(loaded.Create.SelectedLeafIDs) != 2 || loaded.Create.SelectedLeafIDs[1] != "takuzu/takuzu/6x6" {
+		t.Fatalf("loaded create leaves = %#v", loaded.Create.SelectedLeafIDs)
+	}
+}
+
 func TestSaveCreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "deep", "config.json")

--- a/daily/daily_test.go
+++ b/daily/daily_test.go
@@ -154,7 +154,7 @@ func TestEligibleModesHaveMetadata(t *testing.T) {
 	}
 }
 
-func TestEligibleModesIncludeSudokuRGBDailyTiers(t *testing.T) {
+func TestEligibleModesIncludeSudokuRGBVariant(t *testing.T) {
 	found := map[string]bool{}
 	for _, entry := range eligibleModes {
 		if entry.GameType == "Sudoku RGB" {
@@ -162,9 +162,7 @@ func TestEligibleModesIncludeSudokuRGBDailyTiers(t *testing.T) {
 		}
 	}
 
-	for _, mode := range []string{"Easy", "Medium"} {
-		if !found[mode] {
-			t.Fatalf("eligibleModes missing Sudoku RGB %s", mode)
-		}
+	if !found["Sudoku RGB"] {
+		t.Fatalf("eligibleModes missing Sudoku RGB variant")
 	}
 }

--- a/difficulty/candidates.go
+++ b/difficulty/candidates.go
@@ -1,0 +1,43 @@
+package difficulty
+
+import "math"
+
+func CandidateCount(elo Elo) int {
+	score := Score01(elo)
+	if score <= 0 {
+		return 1
+	}
+	return min(8, 1+int(math.Round(score*7)))
+}
+
+func BetterCandidate(candidate, best Report, target Elo, hasBest bool) bool {
+	if !hasBest {
+		return true
+	}
+	candidateDelta := absInt(int(candidate.ActualElo) - int(target))
+	bestDelta := absInt(int(best.ActualElo) - int(target))
+	if candidateDelta != bestDelta {
+		return candidateDelta < bestDelta
+	}
+	return confidenceRank(candidate.Confidence) > confidenceRank(best.Confidence)
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func confidenceRank(confidence Confidence) int {
+	switch confidence {
+	case ConfidenceHigh:
+		return 3
+	case ConfidenceMedium:
+		return 2
+	case ConfidenceLow:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/difficulty/difficulty.go
+++ b/difficulty/difficulty.go
@@ -1,0 +1,50 @@
+// Package difficulty defines PuzzleTea's shared Elo difficulty contract.
+package difficulty
+
+import "fmt"
+
+type Elo int
+
+const (
+	MinElo     Elo = 0
+	SoftCapElo Elo = 3000
+)
+
+type Confidence string
+
+const (
+	ConfidenceLow    Confidence = "low"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceHigh   Confidence = "high"
+)
+
+type Metrics map[string]float64
+
+type Report struct {
+	TargetElo  Elo
+	ActualElo  Elo
+	Confidence Confidence
+	Metrics    Metrics
+}
+
+func ValidateElo(elo Elo) error {
+	if elo < MinElo || elo > SoftCapElo {
+		return fmt.Errorf("difficulty elo %d outside supported range %d..%d", elo, MinElo, SoftCapElo)
+	}
+	return nil
+}
+
+func ClampElo(elo Elo) Elo {
+	if elo < MinElo {
+		return MinElo
+	}
+	if elo > SoftCapElo {
+		return SoftCapElo
+	}
+	return elo
+}
+
+func Score01(elo Elo) float64 {
+	elo = ClampElo(elo)
+	return float64(elo-MinElo) / float64(SoftCapElo-MinElo)
+}

--- a/difficulty/difficulty_test.go
+++ b/difficulty/difficulty_test.go
@@ -1,0 +1,55 @@
+package difficulty
+
+import "testing"
+
+func TestValidateElo(t *testing.T) {
+	for _, elo := range []Elo{MinElo, 600, 1200, 1800, 2400, SoftCapElo} {
+		if err := ValidateElo(elo); err != nil {
+			t.Fatalf("ValidateElo(%d) returned error: %v", elo, err)
+		}
+	}
+
+	for _, elo := range []Elo{-1, SoftCapElo + 1} {
+		if err := ValidateElo(elo); err == nil {
+			t.Fatalf("ValidateElo(%d) returned nil error", elo)
+		}
+	}
+}
+
+func TestClampElo(t *testing.T) {
+	tests := []struct {
+		input Elo
+		want  Elo
+	}{
+		{input: -100, want: MinElo},
+		{input: MinElo, want: MinElo},
+		{input: 1500, want: 1500},
+		{input: SoftCapElo, want: SoftCapElo},
+		{input: 3200, want: SoftCapElo},
+	}
+
+	for _, tt := range tests {
+		if got := ClampElo(tt.input); got != tt.want {
+			t.Fatalf("ClampElo(%d) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestScore01(t *testing.T) {
+	tests := []struct {
+		input Elo
+		want  float64
+	}{
+		{input: -100, want: 0},
+		{input: MinElo, want: 0},
+		{input: 1500, want: 0.5},
+		{input: SoftCapElo, want: 1},
+		{input: 3200, want: 1},
+	}
+
+	for _, tt := range tests {
+		if got := Score01(tt.input); got != tt.want {
+			t.Fatalf("Score01(%d) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/export/pack/packexport_test.go
+++ b/export/pack/packexport_test.go
@@ -39,6 +39,9 @@ func TestRunDeterministicWithFixedSpecAndSeed(t *testing.T) {
 	if string(jsonlA) != string(jsonlB) {
 		t.Fatal("expected identical jsonl output for identical spec and seed")
 	}
+	if !strings.Contains(string(jsonlA), pdfexport.ExportSchemaV2) {
+		t.Fatalf("jsonl schema marker missing %q", pdfexport.ExportSchemaV2)
+	}
 
 	info, err := os.Stat(specA.PDFOutputPath)
 	if err != nil {
@@ -46,6 +49,13 @@ func TestRunDeterministicWithFixedSpecAndSeed(t *testing.T) {
 	}
 	if info.Size() == 0 {
 		t.Fatal("expected non-empty pdf output")
+	}
+}
+
+func TestDefaultSpecUsesPackSchemaV2(t *testing.T) {
+	spec := DefaultSpec(t.TempDir())
+	if spec.Schema != PackSpecSchemaV2 {
+		t.Fatalf("Schema = %q, want %q", spec.Schema, PackSpecSchemaV2)
 	}
 }
 
@@ -106,7 +116,16 @@ func TestValidateSpecRejectsUnknownTargets(t *testing.T) {
 				spec.Counts[puzzle.CanonicalGameID("Sudoku")][puzzle.ModeID("missing-mode")] = 1
 				return spec
 			}(),
-			want: "not a known export mode",
+			want: "not a known export variant",
+		},
+		{
+			name: "unsupported schema",
+			spec: func() Spec {
+				spec := smallTestSpec(dir, "unsupported-schema")
+				spec.Schema = "puzzletea.pack.v1"
+				return spec
+			}(),
+			want: "unsupported pack spec schema",
 		},
 	}
 

--- a/export/pack/render.go
+++ b/export/pack/render.go
@@ -101,27 +101,65 @@ func parseSheetLayout(raw string) (pdfexport.SheetLayout, error) {
 func buildModeDifficultyLookup(definitions []puzzle.Definition) map[string]map[string]float64 {
 	lookup := make(map[string]map[string]float64, len(definitions))
 	for _, def := range definitions {
-		titles := []string{}
+		scores := make(map[string]float64)
+		variantTitles := []string{}
 		for _, variant := range def.Variants {
 			title := strings.TrimSpace(variant.Title)
 			if title == "" {
 				continue
 			}
-			titles = append(titles, title)
+			variantTitles = append(variantTitles, title)
 		}
-		if len(titles) == 0 {
+		addModeOrderScores(scores, variantTitles)
+		addLegacyModeOrderScores(scores, def)
+		if len(scores) == 0 {
 			continue
-		}
-
-		scores := make(map[string]float64, len(titles))
-		if len(titles) == 1 {
-			scores[normalizeDifficultyToken(titles[0])] = 0.5
-		} else {
-			for i, title := range titles {
-				scores[normalizeDifficultyToken(title)] = float64(i) / float64(len(titles)-1)
-			}
 		}
 		lookup[normalizeDifficultyToken(def.Name)] = scores
 	}
 	return lookup
+}
+
+func addLegacyModeOrderScores(scores map[string]float64, def puzzle.Definition) {
+	if len(def.LegacyModes) == 0 {
+		titles := make([]string, 0, len(def.Modes))
+		for _, mode := range def.Modes {
+			title := strings.TrimSpace(mode.Title)
+			if title != "" {
+				titles = append(titles, title)
+			}
+		}
+		addModeOrderScores(scores, titles)
+		return
+	}
+
+	modeIndex := make(map[puzzle.ModeID]int, len(def.Modes))
+	for i, mode := range def.Modes {
+		modeIndex[mode.ID] = i
+	}
+	for _, alias := range def.LegacyModes {
+		title := strings.TrimSpace(alias.Title)
+		if title == "" {
+			continue
+		}
+		i, ok := modeIndex[alias.ID]
+		if !ok || len(def.Modes) <= 1 {
+			scores[normalizeDifficultyToken(title)] = 0.5
+			continue
+		}
+		scores[normalizeDifficultyToken(title)] = float64(i) / float64(len(def.Modes)-1)
+	}
+}
+
+func addModeOrderScores(scores map[string]float64, titles []string) {
+	switch len(titles) {
+	case 0:
+		return
+	case 1:
+		scores[normalizeDifficultyToken(titles[0])] = 0.5
+	default:
+		for i, title := range titles {
+			scores[normalizeDifficultyToken(title)] = float64(i) / float64(len(titles)-1)
+		}
+	}
 }

--- a/export/pack/render.go
+++ b/export/pack/render.go
@@ -102,8 +102,8 @@ func buildModeDifficultyLookup(definitions []puzzle.Definition) map[string]map[s
 	lookup := make(map[string]map[string]float64, len(definitions))
 	for _, def := range definitions {
 		titles := []string{}
-		for _, mode := range def.Modes {
-			title := strings.TrimSpace(mode.Title)
+		for _, variant := range def.Variants {
+			title := strings.TrimSpace(variant.Title)
 			if title == "" {
 				continue
 			}

--- a/export/pack/render.go
+++ b/export/pack/render.go
@@ -52,6 +52,10 @@ func BuildRenderConfig(options RenderOptions, _ []pdfexport.PackDocument) (pdfex
 func AnnotatePuzzlesForPrint(puzzles []pdfexport.Puzzle, definitions []puzzle.Definition) {
 	lookup := buildModeDifficultyLookup(definitions)
 	for i := range puzzles {
+		if puzzles[i].ActualDifficultyElo != nil || puzzles[i].TargetDifficultyElo != nil {
+			continue
+		}
+
 		mode := normalizeDifficultyToken(puzzles[i].ModeSelection)
 		if mode == "" || strings.Contains(mode, "mixed modes") {
 			puzzles[i].DifficultyScore = 0.5

--- a/export/pack/render_test.go
+++ b/export/pack/render_test.go
@@ -1,0 +1,58 @@
+package packexport
+
+import (
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/export/pdf"
+	"github.com/FelineStateMachine/puzzletea/puzzle"
+)
+
+func TestAnnotatePuzzlesForPrintUsesLegacyModeOrder(t *testing.T) {
+	definitions := []puzzle.Definition{{
+		Name: "Sudoku",
+		Variants: []puzzle.VariantDef{
+			puzzle.NewVariantDef(puzzle.VariantSpec{Title: "Sudoku", DefaultElo: 1200}),
+		},
+		LegacyModes: []puzzle.LegacyModeAlias{
+			puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+				Title:           "Easy",
+				TargetVariantID: puzzle.CanonicalVariantID("Sudoku"),
+				PresetElo:       600,
+				XPWeight:        1,
+			}),
+			puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+				Title:           "Medium",
+				TargetVariantID: puzzle.CanonicalVariantID("Sudoku"),
+				PresetElo:       1200,
+				XPWeight:        3,
+			}),
+			puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+				Title:           "Hard",
+				TargetVariantID: puzzle.CanonicalVariantID("Sudoku"),
+				PresetElo:       1800,
+				XPWeight:        7,
+			}),
+		},
+		Modes: []puzzle.ModeDef{
+			{ID: puzzle.CanonicalModeID("Easy"), Title: "Easy"},
+			{ID: puzzle.CanonicalModeID("Medium"), Title: "Medium"},
+			{ID: puzzle.CanonicalModeID("Hard"), Title: "Hard"},
+		},
+	}}
+	puzzles := []pdfexport.Puzzle{{
+		Category:      "Sudoku",
+		ModeSelection: "Hard",
+	}}
+
+	AnnotatePuzzlesForPrint(puzzles, definitions)
+
+	if got, want := puzzles[0].DifficultyScore, 1.0; got != want {
+		t.Fatalf("DifficultyScore = %v, want %v", got, want)
+	}
+	if got, want := puzzles[0].DifficultyConfidence, pdfexport.DifficultyConfidenceHigh; got != want {
+		t.Fatalf("DifficultyConfidence = %q, want %q", got, want)
+	}
+	if got, want := puzzles[0].DifficultySource, "mode-order"; got != want {
+		t.Fatalf("DifficultySource = %q, want %q", got, want)
+	}
+}

--- a/export/pack/runtime.go
+++ b/export/pack/runtime.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/export/pdf"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -20,6 +21,11 @@ var writePDFFn = pdfexport.WritePDF
 
 type randState struct {
 	rng *rand.Rand
+}
+
+type generatedSaveData struct {
+	SaveData json.RawMessage
+	Report   difficulty.Report
 }
 
 func newRandState(seed string) *randState {
@@ -33,15 +39,25 @@ func (r *randState) RNG() *rand.Rand {
 	return r.rng
 }
 
-func spawnSaveData(ctx context.Context, selection modeSelection, state *randState) (json.RawMessage, error) {
+func spawnSaveData(ctx context.Context, selection modeSelection, state *randState, eloSeed string) (generatedSaveData, error) {
 	var (
 		puzzleGame game.Gamer
+		report     difficulty.Report
 		err        error
 	)
 
-	if state != nil {
+	if selection.targetElo != nil {
+		if selection.eloSpawner == nil {
+			return generatedSaveData{}, fmt.Errorf("mode does not support Elo difficulty")
+		}
+		if cancellable, ok := selection.eloSpawner.(game.CancellableEloSpawner); ok {
+			puzzleGame, report, err = cancellable.SpawnEloContext(ctx, eloSeed, *selection.targetElo)
+		} else {
+			puzzleGame, report, err = selection.eloSpawner.SpawnElo(eloSeed, *selection.targetElo)
+		}
+	} else if state != nil {
 		if selection.seededSpawner == nil {
-			return nil, fmt.Errorf("mode does not support deterministic spawning")
+			return generatedSaveData{}, fmt.Errorf("mode does not support deterministic spawning")
 		}
 		rng := state.RNG()
 		if cancellable, ok := selection.seededSpawner.(game.CancellableSeededSpawner); ok {
@@ -55,18 +71,21 @@ func spawnSaveData(ctx context.Context, selection modeSelection, state *randStat
 		puzzleGame, err = selection.spawner.Spawn()
 	}
 	if err != nil {
-		return nil, err
+		return generatedSaveData{}, err
 	}
 
 	save, err := puzzleGame.GetSave()
 	if err != nil {
-		return nil, fmt.Errorf("serialize puzzle: %w", err)
+		return generatedSaveData{}, fmt.Errorf("serialize puzzle: %w", err)
 	}
 	if !json.Valid(save) {
-		return nil, fmt.Errorf("save payload is not valid json")
+		return generatedSaveData{}, fmt.Errorf("save payload is not valid json")
 	}
 
-	return append(json.RawMessage(nil), save...), nil
+	return generatedSaveData{
+		SaveData: append(json.RawMessage(nil), save...),
+		Report:   report,
+	}, nil
 }
 
 func WriteJSONL(path string, records []pdfexport.JSONLRecord) error {

--- a/export/pack/spec.go
+++ b/export/pack/spec.go
@@ -25,6 +25,8 @@ var Version = "dev"
 
 var nowFn = time.Now
 
+const PackSpecSchemaV2 = "puzzletea.pack.v2"
+
 const (
 	DefaultTitle       = "PuzzleTea Sampler"
 	DefaultHeader      = "A small mixed pack that highlights a few PuzzleTea puzzle styles."
@@ -33,6 +35,7 @@ const (
 )
 
 type Spec struct {
+	Schema          string                                  `json:"schema,omitempty"`
 	Title           string                                  `json:"title,omitempty"`
 	Header          string                                  `json:"header,omitempty"`
 	Advert          string                                  `json:"advert,omitempty"`
@@ -88,6 +91,7 @@ func DefaultSpec(cwd string) Spec {
 	}
 
 	spec := Spec{
+		Schema:        PackSpecSchemaV2,
 		Title:         DefaultTitle,
 		Header:        DefaultHeader,
 		Advert:        DefaultAdvert,
@@ -97,14 +101,14 @@ func DefaultSpec(cwd string) Spec {
 		Counts:        zeroCounts(),
 	}
 
-	setDefaultCount(spec.Counts, "Sudoku", "Easy", 2)
-	setDefaultCount(spec.Counts, "Word Search", "Easy 10x10", 2)
-	setDefaultCount(spec.Counts, "Hitori", "Easy", 1)
-	setDefaultCount(spec.Counts, "Nonogram", "Standard", 1)
-	setDefaultCount(spec.Counts, "Nurikabe", "Easy", 1)
-	setDefaultCount(spec.Counts, "Takuzu", "Easy", 1)
-	setDefaultCount(spec.Counts, "Shikaku", "Easy 7x7", 1)
-	setDefaultCount(spec.Counts, "Spell Puzzle", "Easy", 1)
+	setDefaultCount(spec.Counts, "Sudoku", "Sudoku", 2)
+	setDefaultCount(spec.Counts, "Word Search", "Word Search", 2)
+	setDefaultCount(spec.Counts, "Hitori", "Hitori", 1)
+	setDefaultCount(spec.Counts, "Nonogram", "Nonogram", 1)
+	setDefaultCount(spec.Counts, "Nurikabe", "Nurikabe", 1)
+	setDefaultCount(spec.Counts, "Takuzu", "Takuzu", 1)
+	setDefaultCount(spec.Counts, "Shikaku", "Shikaku", 1)
+	setDefaultCount(spec.Counts, "Spell Puzzle", "Spell Puzzle", 1)
 
 	return spec
 }
@@ -117,15 +121,16 @@ func ExportCatalog() []GameCatalog {
 			continue
 		}
 
-		gameModes := make([]ModeCatalog, 0, len(entry.Modes))
-		for _, mode := range entry.Modes {
+		gameModes := make([]ModeCatalog, 0, len(entry.Variants))
+		for _, variant := range entry.Variants {
+			elo := int(variant.Definition.DefaultElo)
 			gameModes = append(gameModes, ModeCatalog{
 				GameID:    entry.Definition.ID,
 				GameType:  entry.Definition.Name,
-				ModeID:    mode.Definition.ID,
-				ModeTitle: mode.Definition.Title,
-				Seeded:    mode.Seeded != nil,
-				PresetElo: intPtrFromElo(mode.Definition.PresetElo),
+				ModeID:    puzzle.ModeID(variant.Definition.ID),
+				ModeTitle: variant.Definition.Title,
+				Seeded:    variant.Seeded != nil,
+				PresetElo: &elo,
 			})
 		}
 
@@ -276,6 +281,9 @@ func setDefaultCount(counts map[puzzle.GameID]map[puzzle.ModeID]int, gameName, m
 func buildRunPlan(spec Spec) (runPlan, error) {
 	spec = normalizeSpec(spec)
 
+	if spec.Schema != PackSpecSchemaV2 {
+		return runPlan{}, fmt.Errorf("unsupported pack spec schema %q", spec.Schema)
+	}
 	if !strings.EqualFold(filepath.Ext(spec.PDFOutputPath), ".pdf") {
 		return runPlan{}, fmt.Errorf("pdf output path must use a .pdf extension")
 	}
@@ -313,9 +321,13 @@ func buildRunPlan(spec Spec) (runPlan, error) {
 			continue
 		}
 
-		modeByID := make(map[puzzle.ModeID]registry.ModeEntry, len(entry.Modes))
-		for _, mode := range entry.Modes {
-			modeByID[mode.Definition.ID] = mode
+		variantByID := make(map[puzzle.ModeID]registry.VariantEntry, len(entry.Variants))
+		for _, variant := range entry.Variants {
+			variantByID[puzzle.ModeID(variant.Definition.ID)] = variant
+		}
+		legacyByID := make(map[puzzle.ModeID]puzzle.LegacyModeAlias, len(entry.LegacyModes))
+		for _, alias := range entry.LegacyModes {
+			legacyByID[alias.ID] = alias
 		}
 
 		for modeID, count := range modes {
@@ -326,25 +338,25 @@ func buildRunPlan(spec Spec) (runPlan, error) {
 				continue
 			}
 
-			mode, ok := modeByID[modeID]
+			variant, targetElo, ok := exportVariantForModeID(entry, variantByID, legacyByID, modeID)
 			if !ok {
-				return runPlan{}, fmt.Errorf("%s / %s is not a known export mode", entry.Definition.Name, modeID)
+				return runPlan{}, fmt.Errorf("%s / %s is not a known export variant", entry.Definition.Name, modeID)
 			}
-			if strings.TrimSpace(spec.Seed) != "" && mode.Seeded == nil {
-				return runPlan{}, fmt.Errorf("%s / %s does not support seeded export", entry.Definition.Name, mode.Definition.Title)
+			if strings.TrimSpace(spec.Seed) != "" && variant.Seeded == nil {
+				return runPlan{}, fmt.Errorf("%s / %s does not support seeded export", entry.Definition.Name, variant.Definition.Title)
 			}
 
 			total += count
 			selections = append(selections, modeSelection{
 				gameID:        entry.Definition.ID,
 				gameType:      entry.Definition.Name,
-				modeID:        mode.Definition.ID,
-				modeTitle:     mode.Definition.Title,
+				modeID:        puzzle.ModeID(variant.Definition.ID),
+				modeTitle:     variant.Definition.Title,
 				count:         count,
-				spawner:       mode.Spawner,
-				seededSpawner: mode.Seeded,
-				eloSpawner:    mode.Elo,
-				targetElo:     cloneElo(mode.Definition.PresetElo),
+				spawner:       variant.Seeded,
+				seededSpawner: variant.Seeded,
+				eloSpawner:    variant.Elo,
+				targetElo:     &targetElo,
 			})
 		}
 	}
@@ -366,7 +378,29 @@ func buildRunPlan(spec Spec) (runPlan, error) {
 	}, nil
 }
 
+func exportVariantForModeID(
+	entry registry.Entry,
+	variantByID map[puzzle.ModeID]registry.VariantEntry,
+	legacyByID map[puzzle.ModeID]puzzle.LegacyModeAlias,
+	modeID puzzle.ModeID,
+) (registry.VariantEntry, difficulty.Elo, bool) {
+	if variant, ok := variantByID[modeID]; ok {
+		return variant, variant.Definition.DefaultElo, true
+	}
+	alias, ok := legacyByID[modeID]
+	if !ok {
+		return registry.VariantEntry{}, 0, false
+	}
+	for _, variant := range entry.Variants {
+		if variant.Definition.ID == alias.TargetVariantID {
+			return variant, alias.PresetElo, true
+		}
+	}
+	return registry.VariantEntry{}, 0, false
+}
+
 func normalizeSpec(spec Spec) Spec {
+	spec.Schema = strings.TrimSpace(spec.Schema)
 	spec.Title = strings.TrimSpace(spec.Title)
 	spec.Header = strings.TrimSpace(spec.Header)
 	spec.Advert = strings.TrimSpace(spec.Advert)
@@ -374,6 +408,9 @@ func normalizeSpec(spec Spec) Spec {
 	spec.PDFOutputPath = strings.TrimSpace(spec.PDFOutputPath)
 	spec.JSONLOutputPath = strings.TrimSpace(spec.JSONLOutputPath)
 
+	if spec.Schema == "" {
+		spec.Schema = PackSpecSchemaV2
+	}
 	if spec.Volume == 0 {
 		spec.Volume = 1
 	}
@@ -427,7 +464,7 @@ func generateRecords(
 			}
 
 			records = append(records, pdfexport.JSONLRecord{
-				Schema: pdfexport.ExportSchemaV1,
+				Schema: pdfexport.ExportSchemaV2,
 				Pack: pdfexport.JSONLPackMeta{
 					Generated:     generatedAt.Format(time.RFC3339),
 					Version:       Version,
@@ -451,22 +488,6 @@ func generateRecords(
 	}
 
 	return records, nil
-}
-
-func intPtrFromElo(elo *difficulty.Elo) *int {
-	if elo == nil {
-		return nil
-	}
-	v := int(*elo)
-	return &v
-}
-
-func cloneElo(elo *difficulty.Elo) *difficulty.Elo {
-	if elo == nil {
-		return nil
-	}
-	v := *elo
-	return &v
 }
 
 func intPtrFromReportElo(elo difficulty.Elo, confidence difficulty.Confidence) *int {

--- a/export/pack/spec.go
+++ b/export/pack/spec.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/export/builtinprint"
 	"github.com/FelineStateMachine/puzzletea/export/pdf"
 	"github.com/FelineStateMachine/puzzletea/game"
@@ -61,6 +62,7 @@ type ModeCatalog struct {
 	ModeID    puzzle.ModeID
 	ModeTitle string
 	Seeded    bool
+	PresetElo *int
 }
 
 type modeSelection struct {
@@ -71,6 +73,8 @@ type modeSelection struct {
 	count         int
 	spawner       game.Spawner
 	seededSpawner game.SeededSpawner
+	eloSpawner    game.EloSpawner
+	targetElo     *difficulty.Elo
 }
 
 type runPlan struct {
@@ -121,6 +125,7 @@ func ExportCatalog() []GameCatalog {
 				ModeID:    mode.Definition.ID,
 				ModeTitle: mode.Definition.Title,
 				Seeded:    mode.Seeded != nil,
+				PresetElo: intPtrFromElo(mode.Definition.PresetElo),
 			})
 		}
 
@@ -338,6 +343,8 @@ func buildRunPlan(spec Spec) (runPlan, error) {
 				count:         count,
 				spawner:       mode.Spawner,
 				seededSpawner: mode.Seeded,
+				eloSpawner:    mode.Elo,
+				targetElo:     cloneElo(mode.Definition.PresetElo),
 			})
 		}
 	}
@@ -405,13 +412,16 @@ func generateRecords(
 	}
 
 	records := make([]pdfexport.JSONLRecord, 0, totalCount)
+	recordIndex := 0
 	for _, selection := range selections {
 		for i := 0; i < selection.count; i++ {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
+			recordIndex++
 
-			saveData, err := spawnSaveData(ctx, selection, rng)
+			eloSeed := scopedPackEloSeed(seed, generatedAt, selection.gameType, selection.modeTitle, recordIndex)
+			generated, err := spawnSaveData(ctx, selection, rng, eloSeed)
 			if err != nil {
 				return nil, fmt.Errorf("generate %s / %s puzzle %d: %w", selection.gameType, selection.modeTitle, i+1, err)
 			}
@@ -427,15 +437,50 @@ func generateRecords(
 					Seed:          seed,
 				},
 				Puzzle: pdfexport.JSONLPuzzle{
-					Index: len(records) + 1,
-					Name:  namegen.GenerateSeeded(nameRNG),
-					Game:  selection.gameType,
-					Mode:  selection.modeTitle,
-					Save:  saveData,
+					Index:                len(records) + 1,
+					Name:                 namegen.GenerateSeeded(nameRNG),
+					Game:                 selection.gameType,
+					Mode:                 selection.modeTitle,
+					TargetDifficultyElo:  intPtrFromReportElo(generated.Report.TargetElo, generated.Report.Confidence),
+					ActualDifficultyElo:  intPtrFromReportElo(generated.Report.ActualElo, generated.Report.Confidence),
+					DifficultyConfidence: string(generated.Report.Confidence),
+					Save:                 generated.SaveData,
 				},
 			})
 		}
 	}
 
 	return records, nil
+}
+
+func intPtrFromElo(elo *difficulty.Elo) *int {
+	if elo == nil {
+		return nil
+	}
+	v := int(*elo)
+	return &v
+}
+
+func cloneElo(elo *difficulty.Elo) *difficulty.Elo {
+	if elo == nil {
+		return nil
+	}
+	v := *elo
+	return &v
+}
+
+func intPtrFromReportElo(elo difficulty.Elo, confidence difficulty.Confidence) *int {
+	if confidence == "" {
+		return nil
+	}
+	v := int(elo)
+	return &v
+}
+
+func scopedPackEloSeed(seed string, generatedAt time.Time, gameType, mode string, index int) string {
+	base := strings.TrimSpace(seed)
+	if base == "" {
+		base = generatedAt.Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("packexport:%s:%s:%s:%d", base, gameType, mode, index)
 }

--- a/export/pdf/jsonl.go
+++ b/export/pdf/jsonl.go
@@ -13,7 +13,10 @@ import (
 	"github.com/FelineStateMachine/puzzletea/difficulty"
 )
 
-const ExportSchemaV1 = "puzzletea.export.v1"
+const (
+	ExportSchemaV1 = "puzzletea.export.v1"
+	ExportSchemaV2 = "puzzletea.export.v2"
+)
 
 type JSONLRecord struct {
 	Schema string        `json:"schema"`
@@ -108,7 +111,7 @@ func parseJSONLScanner(path string, scanner *bufio.Scanner) (PackDocument, error
 		if err := json.Unmarshal([]byte(line), &record); err != nil {
 			return PackDocument{}, fmt.Errorf("%s:%d: decode jsonl record: %w", path, lineNo, err)
 		}
-		if record.Schema != ExportSchemaV1 {
+		if !IsSupportedExportSchema(record.Schema) {
 			return PackDocument{}, fmt.Errorf("%s:%d: unsupported schema %q", path, lineNo, record.Schema)
 		}
 
@@ -185,6 +188,15 @@ func parseJSONLScanner(path string, scanner *bufio.Scanner) (PackDocument, error
 	}
 	doc.Puzzles = puzzles
 	return doc, nil
+}
+
+func IsSupportedExportSchema(schema string) bool {
+	switch schema {
+	case ExportSchemaV1, ExportSchemaV2:
+		return true
+	default:
+		return false
+	}
 }
 
 func annotateJSONLDifficulty(p *Puzzle, puzzle JSONLPuzzle) {

--- a/export/pdf/jsonl.go
+++ b/export/pdf/jsonl.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 )
 
 const ExportSchemaV1 = "puzzletea.export.v1"
@@ -29,11 +31,14 @@ type JSONLPackMeta struct {
 }
 
 type JSONLPuzzle struct {
-	Index int             `json:"index"`
-	Name  string          `json:"name"`
-	Game  string          `json:"game"`
-	Mode  string          `json:"mode"`
-	Save  json.RawMessage `json:"save"`
+	Index                int             `json:"index"`
+	Name                 string          `json:"name"`
+	Game                 string          `json:"game"`
+	Mode                 string          `json:"mode"`
+	TargetDifficultyElo  *int            `json:"target_difficulty_elo,omitempty"`
+	ActualDifficultyElo  *int            `json:"actual_difficulty_elo,omitempty"`
+	DifficultyConfidence string          `json:"difficulty_confidence,omitempty"`
+	Save                 json.RawMessage `json:"save"`
 }
 
 func ParseJSONLFiles(paths []string) ([]PackDocument, error) {
@@ -117,14 +122,17 @@ func parseJSONLScanner(path string, scanner *bufio.Scanner) (PackDocument, error
 		}
 
 		p := Puzzle{
-			SourcePath:     path,
-			SourceFileName: filepath.Base(path),
-			Category:       category,
-			ModeSelection:  mode,
-			Name:           record.Puzzle.Name,
-			Index:          record.Puzzle.Index,
-			SaveData:       append([]byte(nil), record.Puzzle.Save...),
+			SourcePath:          path,
+			SourceFileName:      filepath.Base(path),
+			Category:            category,
+			ModeSelection:       mode,
+			Name:                record.Puzzle.Name,
+			Index:               record.Puzzle.Index,
+			SaveData:            append([]byte(nil), record.Puzzle.Save...),
+			TargetDifficultyElo: cloneInt(record.Puzzle.TargetDifficultyElo),
+			ActualDifficultyElo: cloneInt(record.Puzzle.ActualDifficultyElo),
 		}
+		annotateJSONLDifficulty(&p, record.Puzzle)
 
 		adapter, ok := LookupPrintAdapter(category)
 		if !ok {
@@ -177,4 +185,41 @@ func parseJSONLScanner(path string, scanner *bufio.Scanner) (PackDocument, error
 	}
 	doc.Puzzles = puzzles
 	return doc, nil
+}
+
+func annotateJSONLDifficulty(p *Puzzle, puzzle JSONLPuzzle) {
+	if puzzle.ActualDifficultyElo != nil {
+		elo := difficulty.Elo(*puzzle.ActualDifficultyElo)
+		p.DifficultyScore = difficulty.Score01(elo)
+		p.DifficultyConfidence = parseDifficultyConfidence(puzzle.DifficultyConfidence)
+		p.DifficultySource = "actual-elo"
+		return
+	}
+	if puzzle.TargetDifficultyElo != nil {
+		elo := difficulty.Elo(*puzzle.TargetDifficultyElo)
+		p.DifficultyScore = difficulty.Score01(elo)
+		p.DifficultyConfidence = parseDifficultyConfidence(puzzle.DifficultyConfidence)
+		p.DifficultySource = "target-elo"
+	}
+}
+
+func parseDifficultyConfidence(raw string) DifficultyConfidence {
+	switch difficulty.Confidence(strings.ToLower(strings.TrimSpace(raw))) {
+	case difficulty.ConfidenceLow:
+		return DifficultyConfidenceLow
+	case difficulty.ConfidenceMedium:
+		return DifficultyConfidenceMedium
+	case difficulty.ConfidenceHigh:
+		return DifficultyConfidenceHigh
+	default:
+		return DifficultyConfidenceMedium
+	}
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
 }

--- a/export/pdf/jsonl_difficulty_test.go
+++ b/export/pdf/jsonl_difficulty_test.go
@@ -1,0 +1,92 @@
+package pdfexport
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseJSONLFilePrefersDifficultyElo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pack.jsonl")
+	targetElo := 1200
+	actualElo := 1800
+	record := JSONLRecord{
+		Schema: ExportSchemaV1,
+		Pack: JSONLPackMeta{
+			Generated:     "2026-02-22T10:00:00Z",
+			Version:       "v-test",
+			Category:      "Nonogram",
+			ModeSelection: "Mini",
+			Count:         1,
+		},
+		Puzzle: JSONLPuzzle{
+			Index:                1,
+			Name:                 "ember-newt",
+			Game:                 "Nonogram",
+			Mode:                 "Mini",
+			TargetDifficultyElo:  &targetElo,
+			ActualDifficultyElo:  &actualElo,
+			DifficultyConfidence: "high",
+			Save:                 json.RawMessage(`{"width":2,"height":2,"row-hints":[[1],[1]],"col-hints":[[1],[1]],"state":"  \n  "}`),
+		},
+	}
+	writeSingleJSONLRecord(t, path, record)
+
+	doc, err := ParseJSONLFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	puzzle := doc.Puzzles[0]
+	if puzzle.TargetDifficultyElo == nil || *puzzle.TargetDifficultyElo != targetElo {
+		t.Fatalf("TargetDifficultyElo = %v, want %d", puzzle.TargetDifficultyElo, targetElo)
+	}
+	if puzzle.ActualDifficultyElo == nil || *puzzle.ActualDifficultyElo != actualElo {
+		t.Fatalf("ActualDifficultyElo = %v, want %d", puzzle.ActualDifficultyElo, actualElo)
+	}
+	if got, want := puzzle.DifficultyScore, 0.6; got != want {
+		t.Fatalf("DifficultyScore = %v, want %v", got, want)
+	}
+	if got, want := puzzle.DifficultyConfidence, DifficultyConfidenceHigh; got != want {
+		t.Fatalf("DifficultyConfidence = %q, want %q", got, want)
+	}
+	if got, want := puzzle.DifficultySource, "actual-elo"; got != want {
+		t.Fatalf("DifficultySource = %q, want %q", got, want)
+	}
+}
+
+func TestParseJSONLFileFallsBackToTargetDifficultyElo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pack.jsonl")
+	targetElo := 1500
+	record := JSONLRecord{
+		Schema: ExportSchemaV1,
+		Pack: JSONLPackMeta{
+			Generated:     "2026-02-22T10:00:00Z",
+			Version:       "v-test",
+			Category:      "Nonogram",
+			ModeSelection: "Mini",
+			Count:         1,
+		},
+		Puzzle: JSONLPuzzle{
+			Index:                1,
+			Name:                 "ember-newt",
+			Game:                 "Nonogram",
+			Mode:                 "Mini",
+			TargetDifficultyElo:  &targetElo,
+			DifficultyConfidence: "medium",
+			Save:                 json.RawMessage(`{"width":2,"height":2,"row-hints":[[1],[1]],"col-hints":[[1],[1]],"state":"  \n  "}`),
+		},
+	}
+	writeSingleJSONLRecord(t, path, record)
+
+	doc, err := ParseJSONLFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	puzzle := doc.Puzzles[0]
+	if got, want := puzzle.DifficultyScore, 0.5; got != want {
+		t.Fatalf("DifficultyScore = %v, want %v", got, want)
+	}
+	if got, want := puzzle.DifficultySource, "target-elo"; got != want {
+		t.Fatalf("DifficultySource = %q, want %q", got, want)
+	}
+}

--- a/export/pdf/types.go
+++ b/export/pdf/types.go
@@ -32,6 +32,7 @@ type DifficultyConfidence string
 const (
 	DifficultyConfidenceHigh   DifficultyConfidence = "high"
 	DifficultyConfidenceMedium DifficultyConfidence = "medium"
+	DifficultyConfidenceLow    DifficultyConfidence = "low"
 )
 
 type Puzzle struct {
@@ -47,6 +48,8 @@ type Puzzle struct {
 	DifficultyScore      float64
 	DifficultyConfidence DifficultyConfidence
 	DifficultySource     string
+	TargetDifficultyElo  *int
+	ActualDifficultyElo  *int
 }
 
 type NonogramData struct {

--- a/game/gamer.go
+++ b/game/gamer.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
 )
 
@@ -59,6 +60,17 @@ type CancellableSeededSpawner interface {
 	SpawnSeededContext(ctx context.Context, rng *rand.Rand) (Gamer, error)
 }
 
+// EloSpawner creates a deterministic game instance from seed text and Elo.
+type EloSpawner interface {
+	SpawnElo(seed string, elo difficulty.Elo) (Gamer, difficulty.Report, error)
+}
+
+// CancellableEloSpawner optionally supports context-aware Elo generation.
+type CancellableEloSpawner interface {
+	EloSpawner
+	SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (Gamer, difficulty.Report, error)
+}
+
 // BaseMode provides the common title/description fields and the three
 // Mode-interface methods so that concrete mode structs can embed it
 // instead of duplicating boilerplate.
@@ -89,8 +101,9 @@ func NormalizeName(s string) string {
 
 // SpawnCompleteMsg is sent when an async Spawn() call finishes.
 type SpawnCompleteMsg struct {
-	Game Gamer
-	Err  error
+	Game   Gamer
+	Report difficulty.Report
+	Err    error
 }
 
 // HelpToggleMsg is sent from the root model to games when the user toggles

--- a/gameentry/gameentry.go
+++ b/gameentry/gameentry.go
@@ -4,6 +4,7 @@ package gameentry
 
 import (
 	"fmt"
+	"math/rand/v2"
 
 	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/export/pdf"
@@ -18,12 +19,20 @@ type ModeEntry struct {
 	Elo        game.EloSpawner
 }
 
+type VariantEntry struct {
+	Definition puzzle.VariantDef
+	Elo        game.EloSpawner
+	Seeded     game.SeededSpawner
+}
+
 type Entry struct {
-	Definition puzzle.Definition
-	Help       string
-	Import     func([]byte) (game.Gamer, error)
-	Modes      []ModeEntry
-	Print      pdfexport.PrintAdapter
+	Definition  puzzle.Definition
+	Help        string
+	Import      func([]byte) (game.Gamer, error)
+	Variants    []VariantEntry
+	LegacyModes []puzzle.LegacyModeAlias
+	Modes       []ModeEntry
+	Print       pdfexport.PrintAdapter
 }
 
 type EntrySpec struct {
@@ -49,12 +58,47 @@ func BuildModeDefs(modes []game.Mode) []puzzle.ModeDef {
 	return defs
 }
 
+func BuildDefaultVariantDef(title, description string, defaultElo difficulty.Elo) puzzle.VariantDef {
+	return puzzle.NewVariantDef(puzzle.VariantSpec{
+		Title:       title,
+		Description: description,
+		DefaultElo:  defaultElo,
+	})
+}
+
+func BuildLegacyModeAliases(modes []puzzle.ModeDef, target puzzle.VariantID) []puzzle.LegacyModeAlias {
+	aliases := make([]puzzle.LegacyModeAlias, 0, len(modes))
+	for _, mode := range modes {
+		if mode.PresetElo == nil {
+			continue
+		}
+		aliases = append(aliases, puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+			ID:              mode.ID,
+			Title:           mode.Title,
+			Description:     mode.Description,
+			TargetVariantID: target,
+			PresetElo:       *mode.PresetElo,
+		}))
+	}
+	return aliases
+}
+
 func NewEntry(spec EntrySpec) Entry {
-	if len(spec.Definition.Modes) != len(spec.Modes) {
+	definition := spec.Definition
+	if len(definition.Variants) == 0 && hasEloMode(definition.Modes) {
+		definition.Variants = []puzzle.VariantDef{
+			BuildDefaultVariantDef(definition.Name, definition.Description, defaultEloForModes(definition.Modes)),
+		}
+	}
+	if len(definition.LegacyModes) == 0 && len(definition.Variants) == 1 {
+		definition.LegacyModes = BuildLegacyModeAliases(definition.Modes, definition.Variants[0].ID)
+	}
+
+	if len(definition.Modes) != len(spec.Modes) {
 		panic(fmt.Sprintf(
 			"gameentry: definition %q has %d mode definitions but %d runtime modes",
-			spec.Definition.Name,
-			len(spec.Definition.Modes),
+			definition.Name,
+			len(definition.Modes),
 			len(spec.Modes),
 		))
 	}
@@ -65,16 +109,16 @@ func NewEntry(spec EntrySpec) Entry {
 		if !ok {
 			panic(fmt.Sprintf(
 				"gameentry: definition %q mode %q does not implement game.Spawner",
-				spec.Definition.Name,
+				definition.Name,
 				mode.Title(),
 			))
 		}
 
-		modeDef := spec.Definition.Modes[i]
+		modeDef := definition.Modes[i]
 		if modeDef.Title != mode.Title() || modeDef.Description != mode.Description() {
 			panic(fmt.Sprintf(
 				"gameentry: definition %q mode %d metadata does not match runtime mode %q",
-				spec.Definition.Name,
+				definition.Name,
 				i,
 				mode.Title(),
 			))
@@ -93,7 +137,7 @@ func NewEntry(spec EntrySpec) Entry {
 		if entry.Definition.Seeded != (entry.Seeded != nil) {
 			panic(fmt.Sprintf(
 				"gameentry: definition %q mode %q seeded flag does not match runtime mode",
-				spec.Definition.Name,
+				definition.Name,
 				modeDef.Title,
 			))
 		}
@@ -101,7 +145,7 @@ func NewEntry(spec EntrySpec) Entry {
 			if err := difficulty.ValidateElo(*entry.Definition.PresetElo); err != nil {
 				panic(fmt.Sprintf(
 					"gameentry: definition %q mode %q preset Elo is invalid: %v",
-					spec.Definition.Name,
+					definition.Name,
 					modeDef.Title,
 					err,
 				))
@@ -109,7 +153,7 @@ func NewEntry(spec EntrySpec) Entry {
 			if entry.Elo == nil {
 				panic(fmt.Sprintf(
 					"gameentry: definition %q mode %q has preset Elo but runtime mode does not implement game.EloSpawner",
-					spec.Definition.Name,
+					definition.Name,
 					modeDef.Title,
 				))
 			}
@@ -117,11 +161,117 @@ func NewEntry(spec EntrySpec) Entry {
 		entries = append(entries, entry)
 	}
 
+	variants := buildVariantEntries(definition, entries)
+
 	return Entry{
-		Definition: spec.Definition,
-		Help:       spec.Help,
-		Import:     spec.Import,
-		Modes:      entries,
-		Print:      spec.Print,
+		Definition:  definition,
+		Help:        spec.Help,
+		Import:      spec.Import,
+		Variants:    variants,
+		LegacyModes: append([]puzzle.LegacyModeAlias(nil), definition.LegacyModes...),
+		Modes:       entries,
+		Print:       spec.Print,
 	}
+}
+
+func hasEloMode(modes []puzzle.ModeDef) bool {
+	for _, mode := range modes {
+		if mode.PresetElo != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultEloForModes(modes []puzzle.ModeDef) difficulty.Elo {
+	presets := make([]difficulty.Elo, 0, len(modes))
+	for _, mode := range modes {
+		if mode.PresetElo != nil {
+			presets = append(presets, *mode.PresetElo)
+		}
+	}
+	if len(presets) == 0 {
+		return 1200
+	}
+	return presets[len(presets)/2]
+}
+
+func buildVariantEntries(def puzzle.Definition, modes []ModeEntry) []VariantEntry {
+	if len(def.Variants) == 0 {
+		return nil
+	}
+	result := make([]VariantEntry, 0, len(def.Variants))
+	for _, variant := range def.Variants {
+		spawners := make([]ModeEntry, 0, len(modes))
+		for _, mode := range modes {
+			if mode.Elo != nil {
+				spawners = append(spawners, mode)
+			}
+		}
+		if len(spawners) == 0 {
+			panic(fmt.Sprintf(
+				"gameentry: definition %q variant %q has no Elo-capable legacy modes",
+				def.Name,
+				variant.Title,
+			))
+		}
+		elo := variantEloSpawner{
+			defaultElo: variant.DefaultElo,
+			modes:      spawners,
+		}
+		result = append(result, VariantEntry{
+			Definition: variant,
+			Elo:        elo,
+			Seeded: variantSeededSpawner{
+				elo:        elo,
+				defaultElo: variant.DefaultElo,
+			},
+		})
+	}
+	return result
+}
+
+type variantEloSpawner struct {
+	defaultElo difficulty.Elo
+	modes      []ModeEntry
+}
+
+func (s variantEloSpawner) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	mode := s.modeForElo(elo)
+	return mode.Elo.SpawnElo(seed, elo)
+}
+
+func (s variantEloSpawner) modeForElo(elo difficulty.Elo) ModeEntry {
+	if len(s.modes) == 1 {
+		return s.modes[0]
+	}
+	band := int(elo) * len(s.modes) / (int(difficulty.SoftCapElo) + 1)
+	if band < 0 {
+		band = 0
+	}
+	if band >= len(s.modes) {
+		band = len(s.modes) - 1
+	}
+	return s.modes[band]
+}
+
+type variantSeededSpawner struct {
+	elo        game.EloSpawner
+	defaultElo difficulty.Elo
+}
+
+func (s variantSeededSpawner) Spawn() (game.Gamer, error) {
+	return s.SpawnSeeded(rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())))
+}
+
+func (s variantSeededSpawner) SpawnSeeded(rng *rand.Rand) (game.Gamer, error) {
+	if rng == nil {
+		return nil, fmt.Errorf("nil RNG")
+	}
+	seed := fmt.Sprintf("variant-seeded:%016x:%016x", rng.Uint64(), rng.Uint64())
+	g, _, err := s.elo.SpawnElo(seed, s.defaultElo)
+	return g, err
 }

--- a/gameentry/gameentry.go
+++ b/gameentry/gameentry.go
@@ -5,6 +5,7 @@ package gameentry
 import (
 	"fmt"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/export/pdf"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -14,6 +15,7 @@ type ModeEntry struct {
 	Definition puzzle.ModeDef
 	Spawner    game.Spawner
 	Seeded     game.SeededSpawner
+	Elo        game.EloSpawner
 }
 
 type Entry struct {
@@ -85,12 +87,32 @@ func NewEntry(spec EntrySpec) Entry {
 		if seeded, ok := mode.(game.SeededSpawner); ok {
 			entry.Seeded = seeded
 		}
+		if elo, ok := mode.(game.EloSpawner); ok {
+			entry.Elo = elo
+		}
 		if entry.Definition.Seeded != (entry.Seeded != nil) {
 			panic(fmt.Sprintf(
 				"gameentry: definition %q mode %q seeded flag does not match runtime mode",
 				spec.Definition.Name,
 				modeDef.Title,
 			))
+		}
+		if entry.Definition.PresetElo != nil {
+			if err := difficulty.ValidateElo(*entry.Definition.PresetElo); err != nil {
+				panic(fmt.Sprintf(
+					"gameentry: definition %q mode %q preset Elo is invalid: %v",
+					spec.Definition.Name,
+					modeDef.Title,
+					err,
+				))
+			}
+			if entry.Elo == nil {
+				panic(fmt.Sprintf(
+					"gameentry: definition %q mode %q has preset Elo but runtime mode does not implement game.EloSpawner",
+					spec.Definition.Name,
+					modeDef.Title,
+				))
+			}
 		}
 		entries = append(entries, entry)
 	}

--- a/gameentry/gameentry.go
+++ b/gameentry/gameentry.go
@@ -3,7 +3,9 @@
 package gameentry
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"math/rand/v2"
 
 	"github.com/FelineStateMachine/puzzletea/difficulty"
@@ -68,7 +70,7 @@ func BuildDefaultVariantDef(title, description string, defaultElo difficulty.Elo
 
 func BuildLegacyModeAliases(modes []puzzle.ModeDef, target puzzle.VariantID) []puzzle.LegacyModeAlias {
 	aliases := make([]puzzle.LegacyModeAlias, 0, len(modes))
-	for _, mode := range modes {
+	for i, mode := range modes {
 		if mode.PresetElo == nil {
 			continue
 		}
@@ -78,9 +80,17 @@ func BuildLegacyModeAliases(modes []puzzle.ModeDef, target puzzle.VariantID) []p
 			Description:     mode.Description,
 			TargetVariantID: target,
 			PresetElo:       *mode.PresetElo,
+			XPWeight:        legacyXPWeight(i, len(modes)),
 		}))
 	}
 	return aliases
+}
+
+func legacyXPWeight(index, count int) int {
+	if count <= 0 {
+		return 1
+	}
+	return max(1, int(math.Round(float64(index)/float64(count)*10)))
 }
 
 func NewEntry(spec EntrySpec) Entry {
@@ -237,10 +247,17 @@ type variantEloSpawner struct {
 }
 
 func (s variantEloSpawner) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return s.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (s variantEloSpawner) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 	mode := s.modeForElo(elo)
+	if cancellable, ok := mode.Elo.(game.CancellableEloSpawner); ok {
+		return cancellable.SpawnEloContext(ctx, seed, elo)
+	}
 	return mode.Elo.SpawnElo(seed, elo)
 }
 
@@ -268,10 +285,22 @@ func (s variantSeededSpawner) Spawn() (game.Gamer, error) {
 }
 
 func (s variantSeededSpawner) SpawnSeeded(rng *rand.Rand) (game.Gamer, error) {
+	return s.SpawnSeededContext(context.Background(), rng)
+}
+
+func (s variantSeededSpawner) SpawnSeededContext(ctx context.Context, rng *rand.Rand) (game.Gamer, error) {
 	if rng == nil {
 		return nil, fmt.Errorf("nil RNG")
 	}
 	seed := fmt.Sprintf("variant-seeded:%016x:%016x", rng.Uint64(), rng.Uint64())
-	g, _, err := s.elo.SpawnElo(seed, s.defaultElo)
+	var (
+		g   game.Gamer
+		err error
+	)
+	if cancellable, ok := s.elo.(game.CancellableEloSpawner); ok {
+		g, _, err = cancellable.SpawnEloContext(ctx, seed, s.defaultElo)
+	} else {
+		g, _, err = s.elo.SpawnElo(seed, s.defaultElo)
+	}
 	return g, err
 }

--- a/gameentry/gameentry_test.go
+++ b/gameentry/gameentry_test.go
@@ -1,10 +1,12 @@
 package gameentry
 
 import (
+	"context"
 	"errors"
 	"math/rand/v2"
 	"testing"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
 )
@@ -23,6 +25,23 @@ type seededStubMode struct {
 
 func (m seededStubMode) SpawnSeeded(rng *rand.Rand) (game.Gamer, error) {
 	return nil, errors.New("not implemented")
+}
+
+type cancellableEloStubMode struct {
+	stubMode
+	calledWithCanceledContext bool
+}
+
+func (m *cancellableEloStubMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return nil, difficulty.Report{}, errors.New("non-context spawn called")
+}
+
+func (m *cancellableEloStubMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := ctx.Err(); err != nil {
+		m.calledWithCanceledContext = true
+		return nil, difficulty.Report{}, err
+	}
+	return nil, difficulty.Report{}, nil
 }
 
 func TestBuildModeDefsMarksSeededModes(t *testing.T) {
@@ -71,5 +90,72 @@ func TestNewEntryKeepsMetadataAndRuntimeModesAligned(t *testing.T) {
 	}
 	if entry.Print != nil {
 		t.Fatal("Print = non-nil, want nil")
+	}
+}
+
+func TestVariantEloSpawnerPreservesCancellation(t *testing.T) {
+	preset := difficulty.Elo(1200)
+	mode := &cancellableEloStubMode{
+		stubMode: stubMode{BaseMode: game.NewBaseMode("Hard", "Hard board")},
+	}
+	entry := NewEntry(EntrySpec{
+		Definition: puzzle.NewDefinition(puzzle.DefinitionSpec{
+			Name: "Test",
+			Modes: []puzzle.ModeDef{puzzle.NewModeDef(puzzle.ModeSpec{
+				Title:       mode.Title(),
+				Description: mode.Description(),
+				PresetElo:   &preset,
+			})},
+		}),
+		Modes: []game.Mode{mode},
+	})
+	if len(entry.Variants) != 1 {
+		t.Fatalf("len(Variants) = %d, want 1", len(entry.Variants))
+	}
+	spawner, ok := entry.Variants[0].Elo.(game.CancellableEloSpawner)
+	if !ok {
+		t.Fatal("variant Elo spawner does not implement game.CancellableEloSpawner")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err := spawner.SpawnEloContext(ctx, "seed", preset)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SpawnEloContext error = %v, want context.Canceled", err)
+	}
+	if !mode.calledWithCanceledContext {
+		t.Fatal("underlying mode did not receive the canceled context")
+	}
+}
+
+func TestVariantSeededSpawnerPreservesCancellation(t *testing.T) {
+	preset := difficulty.Elo(1200)
+	mode := &cancellableEloStubMode{
+		stubMode: stubMode{BaseMode: game.NewBaseMode("Hard", "Hard board")},
+	}
+	entry := NewEntry(EntrySpec{
+		Definition: puzzle.NewDefinition(puzzle.DefinitionSpec{
+			Name: "Test",
+			Modes: []puzzle.ModeDef{puzzle.NewModeDef(puzzle.ModeSpec{
+				Title:       mode.Title(),
+				Description: mode.Description(),
+				PresetElo:   &preset,
+			})},
+		}),
+		Modes: []game.Mode{mode},
+	})
+	spawner, ok := entry.Variants[0].Seeded.(game.CancellableSeededSpawner)
+	if !ok {
+		t.Fatal("variant seeded spawner does not implement game.CancellableSeededSpawner")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := spawner.SpawnSeededContext(ctx, rand.New(rand.NewPCG(1, 2)))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SpawnSeededContext error = %v, want context.Canceled", err)
+	}
+	if !mode.calledWithCanceledContext {
+		t.Fatal("underlying mode did not receive the canceled context")
 	}
 }

--- a/games/fillomino/README.md
+++ b/games/fillomino/README.md
@@ -37,6 +37,11 @@ connected group.
 | Hard 10x10 | 10x10 | Longer chains |
 | Expert 12x12 | 12x12 | Broad region planning |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/fillomino/elo.go
+++ b/games/fillomino/elo.go
@@ -18,7 +18,7 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := fillominoModeForElo(elo)
+	mode := fillominoModeForElo(m, elo)
 	puzzle, err := GeneratePuzzleSeeded(mode.Size, mode.Size, mode.MaxRegion, mode.GivenRatio, fillominoEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -30,12 +30,14 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 	return g, fillominoDifficultyReport(elo, mode, puzzle), nil
 }
 
-func fillominoModeForElo(elo difficulty.Elo) Mode {
+func fillominoModeForElo(base Mode, elo difficulty.Elo) Mode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*7))
 	maxRegion := 5 + int(math.Round(score*4))
 	givenRatio := 0.70 - score*0.18
-	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted Fillomino puzzle.", size, maxRegion, givenRatio)
+	mode := base
+	mode.MaxRegion = min(maxRegion, max(1, mode.Size*mode.Size))
+	mode.GivenRatio = givenRatio
+	return mode
 }
 
 func fillominoEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/fillomino/elo.go
+++ b/games/fillomino/elo.go
@@ -1,0 +1,116 @@
+package fillomino
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = Mode{}
+
+func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := fillominoModeForElo(elo)
+	puzzle, err := GeneratePuzzleSeeded(mode.Size, mode.Size, mode.MaxRegion, mode.GivenRatio, fillominoEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	g, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return g, fillominoDifficultyReport(elo, mode, puzzle), nil
+}
+
+func fillominoModeForElo(elo difficulty.Elo) Mode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*7))
+	maxRegion := 5 + int(math.Round(score*4))
+	givenRatio := 0.70 - score*0.18
+	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted Fillomino puzzle.", size, maxRegion, givenRatio)
+}
+
+func fillominoEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("fillomino\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func fillominoDifficultyReport(target difficulty.Elo, mode Mode, puzzle Puzzle) difficulty.Report {
+	solutions := countSolutions(puzzle.Givens, mode.MaxRegion, 2)
+	metrics := fillominoDifficultyMetrics(mode, puzzle, solutions)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  fillominoActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func fillominoDifficultyMetrics(mode Mode, puzzle Puzzle, solutions int) difficulty.Metrics {
+	cells := puzzle.Width * puzzle.Height
+	givens := 0
+	maxRegionValue := 0
+	for _, row := range puzzle.Givens {
+		for _, value := range row {
+			if value == 0 {
+				continue
+			}
+			givens++
+			if value > maxRegionValue {
+				maxRegionValue = value
+			}
+		}
+	}
+	return difficulty.Metrics{
+		"width":            float64(puzzle.Width),
+		"height":           float64(puzzle.Height),
+		"cells":            float64(cells),
+		"given_count":      float64(givens),
+		"unknown_count":    float64(cells - givens),
+		"given_ratio":      fillominoRatio(givens, cells),
+		"target_ratio":     mode.GivenRatio,
+		"max_region":       float64(mode.MaxRegion),
+		"max_given_region": float64(maxRegionValue),
+		"solution_count":   float64(solutions),
+	}
+}
+
+func fillominoActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.40*fillominoNormalize(metrics["cells"], 25, 144) +
+		0.25*(1-fillominoNormalize(metrics["given_ratio"], 0.52, 0.70)) +
+		0.20*fillominoNormalize(metrics["max_region"], 5, 9) +
+		0.15*fillominoNormalize(metrics["unknown_count"], 8, 70)
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func fillominoNormalize(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func fillominoRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/fillomino/elo.go
+++ b/games/fillomino/elo.go
@@ -3,6 +3,7 @@ package fillomino
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"strconv"
@@ -19,25 +20,51 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 	}
 
 	mode := fillominoModeForElo(m, elo)
-	puzzle, err := GeneratePuzzleSeeded(mode.Size, mode.Size, mode.MaxRegion, mode.GivenRatio, fillominoEloRNG(seed, elo))
+	var bestPuzzle Puzzle
+	var bestReport difficulty.Report
+	haveBest := false
+	var lastErr error
+	for candidate := range fillominoEloCandidateCount(elo) {
+		puzzle, err := GeneratePuzzleSeeded(mode.Size, mode.Size, mode.MaxRegion, mode.GivenRatio, fillominoEloRNG(fillominoCandidateSeed(seed, candidate), elo))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		report := fillominoDifficultyReport(elo, mode, puzzle)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestPuzzle = puzzle
+			bestReport = report
+			haveBest = true
+		}
+	}
+	if !haveBest {
+		if lastErr == nil {
+			lastErr = errors.New("unable to generate Elo fillomino")
+		}
+		return nil, difficulty.Report{}, lastErr
+	}
+	g, err := New(mode, bestPuzzle)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	g, err := New(mode, puzzle)
-	if err != nil {
-		return nil, difficulty.Report{}, err
-	}
-	return g, fillominoDifficultyReport(elo, mode, puzzle), nil
+	return g, bestReport, nil
 }
 
 func fillominoModeForElo(base Mode, elo difficulty.Elo) Mode {
 	score := difficulty.Score01(elo)
-	maxRegion := 5 + int(math.Round(score*4))
-	givenRatio := 0.70 - score*0.18
+	maxRegion := 5 + int(math.Round(score*3))
+	givenRatio := 0.70 - score*0.14
 	mode := base
 	mode.MaxRegion = min(maxRegion, max(1, mode.Size*mode.Size))
 	mode.GivenRatio = givenRatio
 	return mode
+}
+
+func fillominoEloCandidateCount(elo difficulty.Elo) int {
+	if elo >= 2400 {
+		return 1
+	}
+	return difficulty.CandidateCount(elo)
 }
 
 func fillominoEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
@@ -46,6 +73,13 @@ func fillominoEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func fillominoCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func fillominoDifficultyReport(target difficulty.Elo, mode Mode, puzzle Puzzle) difficulty.Report {
@@ -93,10 +127,12 @@ func fillominoDifficultyMetrics(mode Mode, puzzle Puzzle, solutions int) difficu
 }
 
 func fillominoActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.40*fillominoNormalize(metrics["cells"], 25, 144) +
+	metricScore := 0.40*fillominoNormalize(metrics["cells"], 25, 144) +
 		0.25*(1-fillominoNormalize(metrics["given_ratio"], 0.52, 0.70)) +
 		0.20*fillominoNormalize(metrics["max_region"], 5, 9) +
 		0.15*fillominoNormalize(metrics["unknown_count"], 8, 70)
+	targetScore := 1 - fillominoNormalize(metrics["target_ratio"], 0.56, 0.70)
+	score := 0.75*targetScore + 0.25*metricScore
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
 }
 

--- a/games/fillomino/elo_test.go
+++ b/games/fillomino/elo_test.go
@@ -1,0 +1,70 @@
+package fillomino
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 6, 6, 0.6)
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 6, 6, 0.6)
+	gameA, reportA, err := mode.SpawnElo("same-seed", 1300)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", 1300)
+	if err != nil {
+		t.Fatal(err)
+	}
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloReportPopulated(t *testing.T) {
+	mode := NewMode("Elo", "test", 6, 6, 0.6)
+	_, report, err := mode.SpawnElo("report-seed", 1800)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.TargetElo != 1800 {
+		t.Fatalf("TargetElo = %d, want 1800", report.TargetElo)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+	for _, key := range []string{"width", "height", "cells", "given_count", "unknown_count", "given_ratio", "target_ratio", "max_region", "solution_count"} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from %+v", key, report.Metrics)
+		}
+	}
+}

--- a/games/fillomino/gamemode.go
+++ b/games/fillomino/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -23,6 +24,7 @@ var (
 	_ game.Mode          = Mode{}
 	_ game.Spawner       = Mode{}
 	_ game.SeededSpawner = Mode{}
+	_ game.EloSpawner    = Mode{}
 )
 
 func NewMode(title, description string, size, maxRegion int, givenRatio float64) Mode {
@@ -58,7 +60,20 @@ var Modes = []game.Mode{
 	NewMode("Expert 12x12", "Wide board with long deduction chains.", 12, 9, 0.52),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = fillominoModeDefinitions(Modes)
+
+func fillominoModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 700, 1300, 2000, 2600}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Fillomino",

--- a/games/hashiwokakero/README.md
+++ b/games/hashiwokakero/README.md
@@ -55,6 +55,11 @@ bridges and all islands are connected.
 | Medium 13x13 | 13x13 | 42-51 | Moderate density |
 | Hard 13x13 | 13x13 | 59-68 | Dense island placement |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/hashiwokakero/elo.go
+++ b/games/hashiwokakero/elo.go
@@ -18,7 +18,7 @@ func (h HashiMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffic
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := hashiModeForElo(elo)
+	mode := hashiModeForElo(h, elo)
 	puzzle, err := GeneratePuzzleSeeded(mode, hashiEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -26,22 +26,21 @@ func (h HashiMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffic
 	return New(mode, puzzle), hashiDifficultyReport(elo, mode, puzzle), nil
 }
 
-func hashiModeForElo(elo difficulty.Elo) HashiMode {
+func hashiModeForElo(base HashiMode, elo difficulty.Elo) HashiMode {
 	score := difficulty.Score01(elo)
-	size := 7 + 2*int(math.Round(score*3))
 	density := 0.17 + score*0.23
-	target := int(math.Round(float64(size*size) * density))
+	cells := base.Width * base.Height
+	target := int(math.Round(float64(cells) * density))
 	minIslands := max(3, target-2)
-	maxIslands := min(size*size, target+2)
+	maxIslands := min(cells, target+2)
+	if minIslands > maxIslands {
+		minIslands = maxIslands
+	}
 
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Hashiwokakero puzzle.",
-		size,
-		size,
-		minIslands,
-		maxIslands,
-	)
+	mode := base
+	mode.MinIslands = minIslands
+	mode.MaxIslands = maxIslands
+	return mode
 }
 
 func hashiEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/hashiwokakero/elo.go
+++ b/games/hashiwokakero/elo.go
@@ -1,0 +1,129 @@
+package hashiwokakero
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = HashiMode{}
+
+func (h HashiMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := hashiModeForElo(elo)
+	puzzle, err := GeneratePuzzleSeeded(mode, hashiEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return New(mode, puzzle), hashiDifficultyReport(elo, mode, puzzle), nil
+}
+
+func hashiModeForElo(elo difficulty.Elo) HashiMode {
+	score := difficulty.Score01(elo)
+	size := 7 + 2*int(math.Round(score*3))
+	density := 0.17 + score*0.23
+	target := int(math.Round(float64(size*size) * density))
+	minIslands := max(3, target-2)
+	maxIslands := min(size*size, target+2)
+
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Hashiwokakero puzzle.",
+		size,
+		size,
+		minIslands,
+		maxIslands,
+	)
+}
+
+func hashiEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	gameID := string(Definition.ID)
+	if gameID == "" {
+		gameID = "hashiwokakero"
+	}
+	sum := sha256.Sum256([]byte(gameID + "\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func hashiDifficultyReport(target difficulty.Elo, mode HashiMode, puzzle Puzzle) difficulty.Report {
+	metrics := hashiDifficultyMetrics(mode, puzzle)
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  hashiActualElo(metrics),
+		Confidence: difficulty.ConfidenceMedium,
+		Metrics:    metrics,
+	}
+}
+
+func hashiDifficultyMetrics(mode HashiMode, puzzle Puzzle) difficulty.Metrics {
+	cells := puzzle.Width * puzzle.Height
+	islands := len(puzzle.Islands)
+	totalRequired := 0
+	maxRequired := 0
+	highRequired := 0
+	for _, island := range puzzle.Islands {
+		totalRequired += island.Required
+		if island.Required > maxRequired {
+			maxRequired = island.Required
+		}
+		if island.Required >= 5 {
+			highRequired++
+		}
+	}
+
+	connectablePairs := len(connectableIslandPairs(&puzzle))
+	return difficulty.Metrics{
+		"width":             float64(puzzle.Width),
+		"height":            float64(puzzle.Height),
+		"cells":             float64(cells),
+		"islands":           float64(islands),
+		"island_density":    hashiRatio(islands, cells),
+		"target_minlands":   float64(mode.MinIslands),
+		"target_maxlands":   float64(mode.MaxIslands),
+		"total_required":    float64(totalRequired),
+		"avg_required":      hashiRatio(totalRequired, islands),
+		"max_required":      float64(maxRequired),
+		"high_required":     float64(highRequired),
+		"connectable_pairs": float64(connectablePairs),
+		"pair_density":      hashiRatio(connectablePairs, max(1, islands)),
+	}
+}
+
+func hashiActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.24*normalizeHashi(metrics["width"], 7, 13) +
+		0.20*normalizeHashi(metrics["island_density"], 0.14, 0.42) +
+		0.17*normalizeHashi(metrics["total_required"]/metrics["cells"], 0.16, 0.58) +
+		0.15*normalizeHashi(metrics["avg_required"], 1.6, 5.0) +
+		0.13*normalizeHashi(metrics["pair_density"], 1.0, 3.5) +
+		0.11*normalizeHashi(metrics["high_required"], 0, metrics["islands"]*0.45)
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeHashi(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func hashiRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/hashiwokakero/elo.go
+++ b/games/hashiwokakero/elo.go
@@ -3,6 +3,7 @@ package hashiwokakero
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"strconv"
@@ -19,16 +20,35 @@ func (h HashiMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffic
 	}
 
 	mode := hashiModeForElo(h, elo)
-	puzzle, err := GeneratePuzzleSeeded(mode, hashiEloRNG(seed, elo))
-	if err != nil {
-		return nil, difficulty.Report{}, err
+	var bestPuzzle Puzzle
+	var bestReport difficulty.Report
+	haveBest := false
+	var lastErr error
+	for candidate := range difficulty.CandidateCount(elo) {
+		puzzle, err := GeneratePuzzleSeeded(mode, hashiEloRNG(hashiCandidateSeed(seed, candidate), elo))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		report := hashiDifficultyReport(elo, mode, puzzle)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestPuzzle = puzzle
+			bestReport = report
+			haveBest = true
+		}
 	}
-	return New(mode, puzzle), hashiDifficultyReport(elo, mode, puzzle), nil
+	if !haveBest {
+		if lastErr == nil {
+			lastErr = errors.New("unable to generate Elo hashi")
+		}
+		return nil, difficulty.Report{}, lastErr
+	}
+	return New(mode, bestPuzzle), bestReport, nil
 }
 
 func hashiModeForElo(base HashiMode, elo difficulty.Elo) HashiMode {
 	score := difficulty.Score01(elo)
-	density := 0.17 + score*0.23
+	density := 0.11 + score*0.29
 	cells := base.Width * base.Height
 	target := int(math.Round(float64(cells) * density))
 	minIslands := max(3, target-2)
@@ -53,6 +73,13 @@ func hashiEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func hashiCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func hashiDifficultyReport(target difficulty.Elo, mode HashiMode, puzzle Puzzle) difficulty.Report {

--- a/games/hashiwokakero/elo_test.go
+++ b/games/hashiwokakero/elo_test.go
@@ -1,0 +1,119 @@
+package hashiwokakero
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 7, 7, 8, 10)
+
+	for _, elo := range []difficulty.Elo{difficulty.MinElo - 1, difficulty.SoftCapElo + 1} {
+		gamer, report, err := mode.SpawnElo("seed", elo)
+		if err == nil {
+			t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+		}
+		if gamer != nil {
+			t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+		}
+		if !reflect.DeepEqual(report, difficulty.Report{}) {
+			t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+		}
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 7, 7, 8, 10)
+	const target = difficulty.Elo(1700)
+
+	gameA, reportA, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("SpawnElo reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 7, 7, 8, 10)
+	const target = difficulty.Elo(2100)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence != difficulty.ConfidenceMedium {
+		t.Fatalf("Confidence = %q, want %q", report.Confidence, difficulty.ConfidenceMedium)
+	}
+
+	requiredMetrics := map[string]float64{
+		"width":             1,
+		"height":            1,
+		"cells":             1,
+		"islands":           1,
+		"island_density":    0,
+		"target_minlands":   1,
+		"target_maxlands":   1,
+		"total_required":    1,
+		"avg_required":      1,
+		"max_required":      1,
+		"high_required":     0,
+		"connectable_pairs": 1,
+		"pair_density":      1,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %v, want >= %v", key, got, min)
+		}
+	}
+	if report.Metrics["island_density"] > 1 {
+		t.Fatalf("island_density = %v, want <= 1", report.Metrics["island_density"])
+	}
+}
+
+func TestModeDefinitionsIncludePresetElo(t *testing.T) {
+	if len(ModeDefinitions) != len(Modes) {
+		t.Fatalf("ModeDefinitions length = %d, want %d", len(ModeDefinitions), len(Modes))
+	}
+	for i, def := range ModeDefinitions {
+		if def.PresetElo == nil {
+			t.Fatalf("ModeDefinitions[%d].PresetElo is nil", i)
+		}
+		if err := difficulty.ValidateElo(*def.PresetElo); err != nil {
+			t.Fatalf("ModeDefinitions[%d].PresetElo = %d is invalid: %v", i, *def.PresetElo, err)
+		}
+	}
+}

--- a/games/hashiwokakero/elo_test.go
+++ b/games/hashiwokakero/elo_test.go
@@ -104,6 +104,20 @@ func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
 	}
 }
 
+func TestSpawnEloPreservesSelectedDimensions(t *testing.T) {
+	mode := NewMode("Easy 7x7", "7x7 grid with 8-10 islands.", 7, 7, 8, 10)
+	_, report, err := mode.SpawnElo("fixed-size", 2800)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if got, want := report.Metrics["width"], 7.0; got != want {
+		t.Fatalf("width metric = %.0f, want %.0f", got, want)
+	}
+	if got, want := report.Metrics["height"], 7.0; got != want {
+		t.Fatalf("height metric = %.0f, want %.0f", got, want)
+	}
+}
+
 func TestModeDefinitionsIncludePresetElo(t *testing.T) {
 	if len(ModeDefinitions) != len(Modes) {
 		t.Fatalf("ModeDefinitions length = %d, want %d", len(ModeDefinitions), len(Modes))

--- a/games/hashiwokakero/gamemode.go
+++ b/games/hashiwokakero/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -24,6 +25,7 @@ var (
 	_ game.Mode          = HashiMode{}
 	_ game.Spawner       = HashiMode{}
 	_ game.SeededSpawner = HashiMode{}
+	_ game.EloSpawner    = HashiMode{}
 )
 
 func NewMode(title, description string, width, height, minIslands, maxIslands int) HashiMode {
@@ -67,7 +69,23 @@ var Modes = []game.Mode{
 	NewMode("Hard 13x13", "13x13 grid with 59-68 islands.", 13, 13, 59, 68),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = hashiModeDefinitions(Modes)
+
+func hashiModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{250, 500, 800, 700, 1100, 1500, 1300, 1700, 2100, 1900, 2400, 2900}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Hashiwokakero",

--- a/games/hitori/README.md
+++ b/games/hitori/README.md
@@ -39,6 +39,11 @@ The puzzle is solved when all three rules hold simultaneously.
 | Hard | 10x10 | Advanced logic chains |
 | Expert | 12x12 | Maximum challenge |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/hitori/elo.go
+++ b/games/hitori/elo.go
@@ -1,0 +1,147 @@
+package hitori
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+func (h HitoriMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := hitoriModeForElo(h, elo)
+	puzzle, err := GenerateSeeded(mode.Size, mode.BlackRatio, hitoriEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	gamer, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, hitoriDifficultyReport(elo, mode, puzzle), nil
+}
+
+func hitoriModeForElo(base HitoriMode, elo difficulty.Elo) HitoriMode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*7))
+	blackRatio := 0.32 - score*0.04
+
+	mode := base
+	mode.BaseMode = game.NewBaseMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Hitori puzzle.",
+	)
+	mode.Size = size
+	mode.BlackRatio = blackRatio
+	return mode
+}
+
+func hitoriEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("hitori\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func hitoriDifficultyReport(target difficulty.Elo, mode HitoriMode, puzzle grid) difficulty.Report {
+	metrics := hitoriDifficultyMetrics(mode, puzzle)
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  hitoriActualElo(metrics),
+		Confidence: difficulty.ConfidenceMedium,
+		Metrics:    metrics,
+	}
+}
+
+func hitoriDifficultyMetrics(mode HitoriMode, puzzle grid) difficulty.Metrics {
+	size := len(puzzle)
+	cells := size * size
+	duplicateCells, duplicateGroups := hitoriDuplicatePressure(puzzle)
+
+	return difficulty.Metrics{
+		"size":             float64(size),
+		"cells":            float64(cells),
+		"target_black_pct": mode.BlackRatio,
+		"duplicate_cells":  float64(duplicateCells),
+		"duplicate_groups": float64(duplicateGroups),
+		"duplicate_pct":    hitoriRatio(duplicateCells, cells),
+		"solution_count":   float64(countPuzzleSolutions(puzzle, size, 2)),
+	}
+}
+
+func hitoriDuplicatePressure(puzzle grid) (int, int) {
+	duplicateCells := 0
+	duplicateGroups := 0
+
+	for _, row := range puzzle {
+		cells, groups := hitoriDuplicateLinePressure(row)
+		duplicateCells += cells
+		duplicateGroups += groups
+	}
+
+	size := len(puzzle)
+	for x := range size {
+		col := make([]rune, size)
+		for y := range size {
+			col[y] = puzzle[y][x]
+		}
+		cells, groups := hitoriDuplicateLinePressure(col)
+		duplicateCells += cells
+		duplicateGroups += groups
+	}
+
+	return duplicateCells, duplicateGroups
+}
+
+func hitoriDuplicateLinePressure(line []rune) (int, int) {
+	counts := make(map[rune]int, len(line))
+	for _, value := range line {
+		counts[value]++
+	}
+
+	cells := 0
+	groups := 0
+	for _, count := range counts {
+		if count < 2 {
+			continue
+		}
+		cells += count
+		groups++
+	}
+	return cells, groups
+}
+
+func hitoriActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.50*hitoriNormalize(metrics["size"], 5, 12) +
+		0.28*hitoriNormalize(metrics["duplicate_pct"], 0.20, 1.20) +
+		0.17*hitoriNormalize(metrics["target_black_pct"], 0.28, 0.34) +
+		0.05*hitoriNormalize(metrics["duplicate_groups"], 4, 36)
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func hitoriNormalize(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func hitoriRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/hitori/elo.go
+++ b/games/hitori/elo.go
@@ -1,6 +1,7 @@
 package hitori
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"math"
@@ -11,22 +12,45 @@ import (
 	"github.com/FelineStateMachine/puzzletea/game"
 )
 
+var _ game.CancellableEloSpawner = HitoriMode{}
+
 func (h HitoriMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return h.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (h HitoriMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
 	mode := hitoriModeForElo(h, elo)
-	puzzle, err := GenerateSeeded(mode.Size, mode.BlackRatio, hitoriEloRNG(seed, elo))
-	if err != nil {
-		return nil, difficulty.Report{}, err
+	var puzzle grid
+	var err error
+	if elo >= 2400 {
+		puzzle = generateFastHitoriEloPuzzle(mode, hitoriEloRNG(seed+"\x00fallback", elo))
+	} else {
+		puzzle, err = GenerateSeededContext(ctx, mode.Size, mode.BlackRatio, hitoriEloRNG(seed, elo))
+		if err != nil {
+			if ctx.Err() == nil {
+				return nil, difficulty.Report{}, err
+			}
+			puzzle = generateFastHitoriEloPuzzle(mode, hitoriEloRNG(seed+"\x00fallback", elo))
+		}
 	}
 
 	gamer, err := New(mode, puzzle)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, hitoriDifficultyReport(elo, mode, puzzle), nil
+	if elo >= 2400 {
+		report := hitoriDifficultyReportWithoutCounting(elo, mode, puzzle)
+		return gamer, report, nil
+	}
+	report := hitoriDifficultyReport(ctx, elo, mode, puzzle)
+	return gamer, report, nil
 }
 
 func hitoriModeForElo(base HitoriMode, elo difficulty.Elo) HitoriMode {
@@ -46,17 +70,45 @@ func hitoriEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 	))
 }
 
-func hitoriDifficultyReport(target difficulty.Elo, mode HitoriMode, puzzle grid) difficulty.Report {
-	metrics := hitoriDifficultyMetrics(mode, puzzle)
+func generateFastHitoriEloPuzzle(mode HitoriMode, rng *rand.Rand) grid {
+	baseGrid := generateLatinSquareSeeded(mode.Size, rng)
+	mask := generateValidMaskSeeded(mode.Size, mode.BlackRatio, rng)
+	return constructPuzzleSeeded(baseGrid, mask, rng)
+}
+
+func hitoriDifficultyReport(ctx context.Context, target difficulty.Elo, mode HitoriMode, puzzle grid) difficulty.Report {
+	metrics := hitoriDifficultyMetrics(ctx, mode, puzzle)
+	confidence := difficulty.ConfidenceMedium
+	if metrics["solution_count"] < 0 {
+		confidence = difficulty.ConfidenceLow
+	}
 	return difficulty.Report{
 		TargetElo:  target,
 		ActualElo:  hitoriActualElo(metrics),
-		Confidence: difficulty.ConfidenceMedium,
+		Confidence: confidence,
 		Metrics:    metrics,
 	}
 }
 
-func hitoriDifficultyMetrics(mode HitoriMode, puzzle grid) difficulty.Metrics {
+func hitoriDifficultyReportWithoutCounting(target difficulty.Elo, mode HitoriMode, puzzle grid) difficulty.Report {
+	metrics := hitoriDifficultyMetricsWithoutCounting(mode, puzzle)
+	metrics["solution_count"] = -1
+	metrics["solver_limited"] = 1
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  hitoriActualElo(metrics),
+		Confidence: difficulty.ConfidenceLow,
+		Metrics:    metrics,
+	}
+}
+
+func hitoriDifficultyMetrics(ctx context.Context, mode HitoriMode, puzzle grid) difficulty.Metrics {
+	metrics := hitoriDifficultyMetricsWithoutCounting(mode, puzzle)
+	metrics["solution_count"] = float64(countPuzzleSolutionsContext(ctx, puzzle, len(puzzle), 2))
+	return metrics
+}
+
+func hitoriDifficultyMetricsWithoutCounting(mode HitoriMode, puzzle grid) difficulty.Metrics {
 	size := len(puzzle)
 	cells := size * size
 	duplicateCells, duplicateGroups := hitoriDuplicatePressure(puzzle)
@@ -68,7 +120,6 @@ func hitoriDifficultyMetrics(mode HitoriMode, puzzle grid) difficulty.Metrics {
 		"duplicate_cells":  float64(duplicateCells),
 		"duplicate_groups": float64(duplicateGroups),
 		"duplicate_pct":    hitoriRatio(duplicateCells, cells),
-		"solution_count":   float64(countPuzzleSolutions(puzzle, size, 2)),
 	}
 }
 
@@ -115,10 +166,12 @@ func hitoriDuplicateLinePressure(line []rune) (int, int) {
 }
 
 func hitoriActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.50*hitoriNormalize(metrics["size"], 5, 12) +
+	metricScore := 0.50*hitoriNormalize(metrics["size"], 5, 12) +
 		0.28*hitoriNormalize(metrics["duplicate_pct"], 0.20, 1.20) +
-		0.17*hitoriNormalize(metrics["target_black_pct"], 0.28, 0.34) +
+		0.17*(1-hitoriNormalize(metrics["target_black_pct"], 0.27, 0.32)) +
 		0.05*hitoriNormalize(metrics["duplicate_groups"], 4, 36)
+	targetScore := 1 - hitoriNormalize(metrics["target_black_pct"], 0.28, 0.32)
+	score := 0.50*targetScore + 0.50*metricScore
 
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
 }

--- a/games/hitori/elo.go
+++ b/games/hitori/elo.go
@@ -31,15 +31,9 @@ func (h HitoriMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 
 func hitoriModeForElo(base HitoriMode, elo difficulty.Elo) HitoriMode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*7))
 	blackRatio := 0.32 - score*0.04
 
 	mode := base
-	mode.BaseMode = game.NewBaseMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Hitori puzzle.",
-	)
-	mode.Size = size
 	mode.BlackRatio = blackRatio
 	return mode
 }

--- a/games/hitori/elo_test.go
+++ b/games/hitori/elo_test.go
@@ -1,0 +1,92 @@
+package hitori
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 5, 0.32)
+
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error for invalid Elo")
+	}
+	if gamer != nil {
+		t.Fatalf("SpawnElo gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("SpawnElo report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 5, 0.32)
+	target := difficulty.Elo(1500)
+
+	gamerA, reportA, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("SpawnElo reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 5, 0.32)
+	target := difficulty.Elo(2200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if report.ActualElo < difficulty.MinElo || report.ActualElo > difficulty.SoftCapElo {
+		t.Fatalf("ActualElo = %d, want in supported range", report.ActualElo)
+	}
+	if report.Confidence != difficulty.ConfidenceMedium {
+		t.Fatalf("Confidence = %q, want %q", report.Confidence, difficulty.ConfidenceMedium)
+	}
+
+	requiredMetrics := []string{
+		"size",
+		"cells",
+		"target_black_pct",
+		"duplicate_cells",
+		"duplicate_groups",
+		"duplicate_pct",
+		"solution_count",
+	}
+	for _, name := range requiredMetrics {
+		if _, ok := report.Metrics[name]; !ok {
+			t.Fatalf("report metric %q missing from %#v", name, report.Metrics)
+		}
+	}
+	if report.Metrics["solution_count"] != 1 {
+		t.Fatalf("solution_count = %v, want 1", report.Metrics["solution_count"])
+	}
+}

--- a/games/hitori/elo_test.go
+++ b/games/hitori/elo_test.go
@@ -1,6 +1,7 @@
 package hitori
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -19,6 +20,23 @@ func TestSpawnEloRejectsInvalidElo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(report, difficulty.Report{}) {
 		t.Fatalf("SpawnElo report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloContextCanceled(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 5, 0.32)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gamer, report, err := mode.SpawnEloContext(ctx, "seed", 1200)
+	if err == nil {
+		t.Fatal("SpawnEloContext returned nil error for canceled context")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
 	}
 }
 

--- a/games/hitori/gamemode.go
+++ b/games/hitori/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -22,6 +23,7 @@ var (
 	_ game.Mode          = HitoriMode{}
 	_ game.Spawner       = HitoriMode{}
 	_ game.SeededSpawner = HitoriMode{}
+	_ game.EloSpawner    = HitoriMode{}
 )
 
 func NewMode(title, desc string, size int, blackRatio float64) HitoriMode {
@@ -57,7 +59,23 @@ var Modes = []game.Mode{
 	NewMode("Expert", "12\u00d712 grid, maximum challenge.", 12, 0.28),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = hitoriModeDefinitions(Modes)
+
+func hitoriModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 700, 1300, 1800, 2300, 2800}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Hitori",

--- a/games/hitori/generator.go
+++ b/games/hitori/generator.go
@@ -3,6 +3,7 @@ package hitori
 import (
 	"errors"
 	"math/rand/v2"
+	"sort"
 )
 
 type cellPos struct{ x, y int }
@@ -341,6 +342,9 @@ func cellCandidates(puzzle grid, mask [][]bool, size, x, y int) []rune {
 	for num := range seen {
 		result = append(result, num)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
 	return result
 }
 

--- a/games/hitori/generator.go
+++ b/games/hitori/generator.go
@@ -1,6 +1,7 @@
 package hitori
 
 import (
+	"context"
 	"errors"
 	"math/rand/v2"
 	"sort"
@@ -225,10 +226,7 @@ func constructPuzzleSeeded(baseGrid grid, mask [][]bool, rng *rand.Rand) grid {
 	return puzzle
 }
 
-// refinePuzzleSeeded tries different number assignments for black cells to achieve
-// a unique solution. It iterates through each black cell trying all possible
-// duplicate values, checking if the resulting puzzle has exactly one solution.
-func refinePuzzleSeeded(puzzle grid, mask [][]bool, size int, rng *rand.Rand) (grid, bool) {
+func refinePuzzleSeededContext(ctx context.Context, puzzle grid, mask [][]bool, size int, rng *rand.Rand) (grid, bool) {
 	// Collect black cell positions.
 	var blackCells []cellPos
 	for y := range size {
@@ -240,13 +238,16 @@ func refinePuzzleSeeded(puzzle grid, mask [][]bool, size int, rng *rand.Rand) (g
 	}
 
 	if len(blackCells) == 0 {
-		return puzzle, countPuzzleSolutions(puzzle, size, 2) == 1
+		return puzzle, countPuzzleSolutionsContext(ctx, puzzle, size, 2) == 1
 	}
 
 	// Try to refine each black cell's value to reduce solution count.
 	refined := puzzle.clone()
-	currentCount := countPuzzleSolutions(refined, size, 3)
+	currentCount := countPuzzleSolutionsContext(ctx, refined, size, 3)
 	for _, bc := range blackCells {
+		if ctx.Err() != nil {
+			return refined, false
+		}
 		// Collect candidate numbers for this black cell.
 		candidates := cellCandidates(refined, mask, size, bc.x, bc.y)
 		rankRefinementCandidates(refined, mask, size, bc.x, bc.y, candidates, rng)
@@ -259,7 +260,7 @@ func refinePuzzleSeeded(puzzle grid, mask [][]bool, size int, rng *rand.Rand) (g
 				continue
 			}
 			refined[bc.y][bc.x] = num
-			c := countPuzzleSolutions(refined, size, 3)
+			c := countPuzzleSolutionsContext(ctx, refined, size, 3)
 			if c == 1 {
 				return refined, true
 			}
@@ -276,7 +277,7 @@ func refinePuzzleSeeded(puzzle grid, mask [][]bool, size int, rng *rand.Rand) (g
 		}
 	}
 
-	return refined, countPuzzleSolutions(refined, size, 2) == 1
+	return refined, countPuzzleSolutionsContext(ctx, refined, size, 2) == 1
 }
 
 func rankRefinementCandidates(
@@ -358,20 +359,28 @@ const (
 )
 
 func countPuzzleSolutions(puzzle grid, size, limit int) int {
+	return countPuzzleSolutionsContext(context.Background(), puzzle, size, limit)
+}
+
+func countPuzzleSolutionsContext(ctx context.Context, puzzle grid, size, limit int) int {
 	st := make([][]solverState, size)
 	for y := range size {
 		st[y] = make([]solverState, size)
 	}
 	order := rowMajorOrder(size)
-	return solveBT(puzzle, st, order, 0, limit)
+	return solveBTContext(ctx, puzzle, st, order, 0, limit)
 }
 
-func solveBT(
+func solveBTContext(
+	ctx context.Context,
 	puzzle grid,
 	st [][]solverState,
 	order []cellPos,
 	pos, limit int,
 ) int {
+	if ctx.Err() != nil {
+		return -1
+	}
 	size := len(st)
 	if pos == len(order) {
 		marks := stateToMarks(st, size)
@@ -396,8 +405,13 @@ func solveBT(
 
 	if whiteOK {
 		st[y][x] = white
-		count += solveBT(puzzle, st, order, pos+1, limit-count)
+		n := solveBTContext(ctx, puzzle, st, order, pos+1, limit-count)
 		st[y][x] = unknown
+		if n < 0 {
+			order[pos], order[nextIdx] = order[nextIdx], order[pos]
+			return n
+		}
+		count += n
 		if count >= limit {
 			order[pos], order[nextIdx] = order[nextIdx], order[pos]
 			return count
@@ -406,8 +420,13 @@ func solveBT(
 
 	if blackOK {
 		st[y][x] = black
-		count += solveBT(puzzle, st, order, pos+1, limit-count)
+		n := solveBTContext(ctx, puzzle, st, order, pos+1, limit-count)
 		st[y][x] = unknown
+		if n < 0 {
+			order[pos], order[nextIdx] = order[nextIdx], order[pos]
+			return n
+		}
+		count += n
 		if count >= limit {
 			order[pos], order[nextIdx] = order[nextIdx], order[pos]
 			return count
@@ -511,20 +530,27 @@ func Generate(size int, blackRatio float64) (grid, error) {
 }
 
 func GenerateSeeded(size int, blackRatio float64, rng *rand.Rand) (grid, error) {
+	return GenerateSeededContext(context.Background(), size, blackRatio, rng)
+}
+
+func GenerateSeededContext(ctx context.Context, size int, blackRatio float64, rng *rand.Rand) (grid, error) {
 	const maxAttempts = 200
 
 	for range maxAttempts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		baseGrid := generateLatinSquareSeeded(size, rng)
 		mask := generateValidMaskSeeded(size, blackRatio, rng)
 		puzzle := constructPuzzleSeeded(baseGrid, mask, rng)
 
 		// First try the random construction.
-		if countPuzzleSolutions(puzzle, size, 2) == 1 {
+		if countPuzzleSolutionsContext(ctx, puzzle, size, 2) == 1 {
 			return puzzle, nil
 		}
 
 		// Refine by trying different values for black cells.
-		refined, ok := refinePuzzleSeeded(puzzle, mask, size, rng)
+		refined, ok := refinePuzzleSeededContext(ctx, puzzle, mask, size, rng)
 		if ok {
 			return refined, nil
 		}

--- a/games/lightsout/README.md
+++ b/games/lightsout/README.md
@@ -30,6 +30,11 @@ goal is to turn every light off.
 | Hard | 7x7 | Large grid |
 | Extreme | 9x9 | Maximum size |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/lightsout/elo.go
+++ b/games/lightsout/elo.go
@@ -23,22 +23,18 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 		return nil, difficulty.Report{}, err
 	}
 
-	spec := lightsOutSpecForElo(elo)
+	spec := lightsOutSpecForMode(m)
 	rng := lightsOutRandForElo(seed, elo)
 	grid, report := generateLightsOutEloGrid(spec, rng, elo)
 
 	mode := m
-	mode.Width = spec.width
-	mode.Height = spec.height
 
 	g := newFromGrid(mode.Width, mode.Height, grid)
 	return g, report, nil
 }
 
-func lightsOutSpecForElo(elo difficulty.Elo) eloSpec {
-	score := difficulty.Score01(elo)
-	size := 3 + 2*int(math.Round(score*3))
-	return eloSpec{width: size, height: size}
+func lightsOutSpecForMode(mode Mode) eloSpec {
+	return eloSpec{width: mode.Width, height: mode.Height}
 }
 
 func lightsOutRandForElo(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/lightsout/elo.go
+++ b/games/lightsout/elo.go
@@ -1,0 +1,186 @@
+package lightsout
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = Mode{}
+
+type eloSpec struct {
+	width  int
+	height int
+}
+
+func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	spec := lightsOutSpecForElo(elo)
+	rng := lightsOutRandForElo(seed, elo)
+	grid, report := generateLightsOutEloGrid(spec, rng, elo)
+
+	mode := m
+	mode.Width = spec.width
+	mode.Height = spec.height
+
+	g := newFromGrid(mode.Width, mode.Height, grid)
+	return g, report, nil
+}
+
+func lightsOutSpecForElo(elo difficulty.Elo) eloSpec {
+	score := difficulty.Score01(elo)
+	size := 3 + 2*int(math.Round(score*3))
+	return eloSpec{width: size, height: size}
+}
+
+func lightsOutRandForElo(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("lightsout\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func generateLightsOutEloGrid(spec eloSpec, rng *rand.Rand, target difficulty.Elo) ([][]bool, difficulty.Report) {
+	best := GenerateSeeded(spec.width, spec.height, rng)
+	bestReport := scoreLightsOutGrid(target, best)
+
+	for range 23 {
+		candidate := GenerateSeeded(spec.width, spec.height, rng)
+		report := scoreLightsOutGrid(target, candidate)
+		if eloDistance(report.ActualElo, target) < eloDistance(bestReport.ActualElo, target) {
+			best = candidate
+			bestReport = report
+		}
+	}
+
+	return best, bestReport
+}
+
+func scoreLightsOutGrid(target difficulty.Elo, grid [][]bool) difficulty.Report {
+	metrics := lightsOutMetrics(grid)
+	score := 0.45*normalizeLightsOut(metrics["cells"], 9, 81) +
+		0.35*normalizeLightsOut(metrics["min_solution_moves"], 1, 41) +
+		0.20*normalizeLightsOut(metrics["lights_on"], 1, 81)
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo)))),
+		Confidence: difficulty.ConfidenceHigh,
+		Metrics:    metrics,
+	}
+}
+
+func lightsOutMetrics(grid [][]bool) difficulty.Metrics {
+	height := len(grid)
+	width := 0
+	if height > 0 {
+		width = len(grid[0])
+	}
+	cells := width * height
+	lightsOn := 0
+	for y := range grid {
+		for x := range grid[y] {
+			if grid[y][x] {
+				lightsOn++
+			}
+		}
+	}
+
+	minMoves, solved := minSolutionMoves(grid)
+	solvable := 0.0
+	if solved {
+		solvable = 1
+	}
+
+	return difficulty.Metrics{
+		"width":              float64(width),
+		"height":             float64(height),
+		"cells":              float64(cells),
+		"lights_on":          float64(lightsOn),
+		"light_density":      ratio(lightsOn, cells),
+		"min_solution_moves": float64(minMoves),
+		"move_density":       ratio(minMoves, cells),
+		"solvable":           solvable,
+	}
+}
+
+func minSolutionMoves(grid [][]bool) (int, bool) {
+	height := len(grid)
+	if height == 0 {
+		return 0, true
+	}
+	width := len(grid[0])
+	if width == 0 {
+		return 0, true
+	}
+
+	best := width*height + 1
+	for firstRowMask := range 1 << width {
+		work := copyBoolGrid(grid)
+		moves := 0
+
+		for x := range width {
+			if firstRowMask&(1<<x) != 0 {
+				Toggle(work, x, 0)
+				moves++
+			}
+		}
+
+		for y := 1; y < height; y++ {
+			for x := range width {
+				if work[y-1][x] {
+					Toggle(work, x, y)
+					moves++
+				}
+			}
+		}
+
+		if IsSolved(work) && moves < best {
+			best = moves
+		}
+	}
+
+	if best == width*height+1 {
+		return 0, false
+	}
+	return best, true
+}
+
+func copyBoolGrid(grid [][]bool) [][]bool {
+	copied := make([][]bool, len(grid))
+	for y := range grid {
+		copied[y] = make([]bool, len(grid[y]))
+		copy(copied[y], grid[y])
+	}
+	return copied
+}
+
+func normalizeLightsOut(value, minValue, maxValue float64) float64 {
+	if maxValue <= minValue {
+		return 0
+	}
+	return math.Max(0, math.Min(1, (value-minValue)/(maxValue-minValue)))
+}
+
+func ratio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+func eloDistance(a, b difficulty.Elo) difficulty.Elo {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/games/lightsout/elo_test.go
+++ b/games/lightsout/elo_test.go
@@ -103,3 +103,19 @@ func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
 		}
 	}
 }
+
+func TestSpawnEloPreservesSelectedDimensions(t *testing.T) {
+	mode := NewMode("Easy", "3x3 grid", 3, 3)
+	for _, elo := range []difficulty.Elo{100, 2800} {
+		_, report, err := mode.SpawnElo("fixed-size", elo)
+		if err != nil {
+			t.Fatalf("SpawnElo(%d) returned error: %v", elo, err)
+		}
+		if got, want := report.Metrics["width"], 3.0; got != want {
+			t.Fatalf("SpawnElo(%d) width metric = %.0f, want %.0f", elo, got, want)
+		}
+		if got, want := report.Metrics["height"], 3.0; got != want {
+			t.Fatalf("SpawnElo(%d) height metric = %.0f, want %.0f", elo, got, want)
+		}
+	}
+}

--- a/games/lightsout/elo_test.go
+++ b/games/lightsout/elo_test.go
@@ -1,0 +1,105 @@
+package lightsout
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5)
+
+	tests := []difficulty.Elo{
+		difficulty.MinElo - 1,
+		difficulty.SoftCapElo + 1,
+	}
+	for _, elo := range tests {
+		t.Run(fmt.Sprint(elo), func(t *testing.T) {
+			gamer, report, err := mode.SpawnElo("seed", elo)
+			if err == nil {
+				t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+			}
+			if gamer != nil {
+				t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+			}
+			if !reflect.DeepEqual(report, difficulty.Report{}) {
+				t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+			}
+		})
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5)
+	const seed = "lightsout-deterministic"
+	const elo = difficulty.Elo(1700)
+
+	gamerA, reportA, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gamerA.(Model).GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.(Model).GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("report mismatch for same seed/Elo:\n%#v\n\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5)
+	const target = difficulty.Elo(2200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	requiredMetrics := map[string]float64{
+		"width":              1,
+		"height":             1,
+		"cells":              1,
+		"lights_on":          1,
+		"light_density":      0,
+		"min_solution_moves": 1,
+		"move_density":       0,
+		"solvable":           1,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %v, want >= %v", key, got, min)
+		}
+	}
+}

--- a/games/lightsout/gamemode.go
+++ b/games/lightsout/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -21,6 +22,7 @@ var (
 	_ game.Mode          = Mode{}
 	_ game.Spawner       = Mode{}
 	_ game.SeededSpawner = Mode{}
+	_ game.EloSpawner    = Mode{}
 )
 
 func NewMode(title, desc string, w, h int) Mode {
@@ -46,7 +48,20 @@ var Modes = []game.Mode{
 	NewMode("Extreme", "9x9 grid", 9, 9),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = lightsOutModeDefinitions(Modes)
+
+func lightsOutModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{0, 1000, 2000, 3000}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Lights Out",

--- a/games/netwalk/README.md
+++ b/games/netwalk/README.md
@@ -4,6 +4,11 @@ Rotate network tiles until every active connection reaches the server in one loo
 
 ![Netwalk gameplay](../vhs/netwalk.gif)
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/netwalk/elo.go
+++ b/games/netwalk/elo.go
@@ -16,7 +16,7 @@ func (m NetwalkMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := netwalkModeForElo(elo)
+	mode := netwalkModeForElo(m, elo)
 	puzzle, err := GenerateSeededWithDensity(mode.Size, mode.FillRatio, mode.Profile, netwalkEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -29,19 +29,15 @@ func (m NetwalkMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 	return gamer, netwalkDifficultyReport(elo, mode, puzzle), nil
 }
 
-func netwalkModeForElo(elo difficulty.Elo) NetwalkMode {
+func netwalkModeForElo(base NetwalkMode, elo difficulty.Elo) NetwalkMode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*4))*2
 	fillRatio := 0.50 + score*0.28
 	profile := netwalkProfileForElo(score)
 
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Netwalk puzzle.",
-		size,
-		fillRatio,
-		profile,
-	)
+	mode := base
+	mode.FillRatio = fillRatio
+	mode.Profile = profile
+	return mode
 }
 
 func netwalkProfileForElo(score float64) generateProfile {

--- a/games/netwalk/elo.go
+++ b/games/netwalk/elo.go
@@ -1,0 +1,151 @@
+package netwalk
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+func (m NetwalkMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := netwalkModeForElo(elo)
+	puzzle, err := GenerateSeededWithDensity(mode.Size, mode.FillRatio, mode.Profile, netwalkEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	gamer, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, netwalkDifficultyReport(elo, mode, puzzle), nil
+}
+
+func netwalkModeForElo(elo difficulty.Elo) NetwalkMode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*4))*2
+	fillRatio := 0.50 + score*0.28
+	profile := netwalkProfileForElo(score)
+
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Netwalk puzzle.",
+		size,
+		fillRatio,
+		profile,
+	)
+}
+
+func netwalkProfileForElo(score float64) generateProfile {
+	switch {
+	case score < 0.20:
+		return miniProfile
+	case score < 0.42:
+		return easyProfile
+	case score < 0.65:
+		return mediumProfile
+	case score < 0.86:
+		return hardProfile
+	default:
+		return expertProfile
+	}
+}
+
+func netwalkEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("netwalk\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func netwalkDifficultyReport(target difficulty.Elo, mode NetwalkMode, puzzle Puzzle) difficulty.Report {
+	metrics := netwalkDifficultyMetrics(mode, puzzle)
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  netwalkActualElo(metrics),
+		Confidence: difficulty.ConfidenceMedium,
+		Metrics:    metrics,
+	}
+}
+
+func netwalkDifficultyMetrics(mode NetwalkMode, puzzle Puzzle) difficulty.Metrics {
+	state := analyzePuzzle(puzzle)
+	metrics := difficulty.Metrics{
+		"size":            float64(puzzle.Size),
+		"cells":           float64(puzzle.Size * puzzle.Size),
+		"active_tiles":    float64(state.nonEmpty),
+		"density":         safeFloatRatio(state.nonEmpty, puzzle.Size*puzzle.Size),
+		"target_density":  mode.FillRatio,
+		"connected_tiles": float64(state.connected),
+		"dangling_edges":  float64(state.dangling),
+		"locked_tiles":    float64(state.locked),
+	}
+
+	rotationOptions := 0
+	for y := range puzzle.Size {
+		for x := range puzzle.Size {
+			t := puzzle.Tiles[y][x]
+			if !isActive(t) {
+				continue
+			}
+			rotationOptions += len(uniqueRotations(t.BaseMask))
+			switch degree(t.BaseMask) {
+			case 1:
+				metrics["leaf_tiles"]++
+			case 2:
+				if t.BaseMask == north|south || t.BaseMask == east|west {
+					metrics["straight_tiles"]++
+				} else {
+					metrics["elbow_tiles"]++
+				}
+			case 3:
+				metrics["tee_tiles"]++
+			case 4:
+				metrics["cross_tiles"]++
+			}
+			if t.Rotation != 0 {
+				metrics["initially_rotated_tiles"]++
+			}
+		}
+	}
+	metrics["rotation_options"] = float64(rotationOptions)
+	metrics["avg_rotation_options"] = safeFloatRatio(rotationOptions, state.nonEmpty)
+	return metrics
+}
+
+func netwalkActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.24*normalizeFloat(metrics["size"], 5, 13) +
+		0.20*normalizeFloat(metrics["density"], 0.20, 0.80) +
+		0.18*normalizeFloat(metrics["tee_tiles"]+metrics["cross_tiles"], 0, 18) +
+		0.14*normalizeFloat(metrics["elbow_tiles"], 0, 32) +
+		0.14*normalizeFloat(metrics["avg_rotation_options"], 1, 4) +
+		0.10*normalizeFloat(metrics["initially_rotated_tiles"], 0, metrics["active_tiles"])
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeFloat(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func safeFloatRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/netwalk/elo.go
+++ b/games/netwalk/elo.go
@@ -3,6 +3,7 @@ package netwalk
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"strconv"
@@ -17,21 +18,40 @@ func (m NetwalkMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 	}
 
 	mode := netwalkModeForElo(m, elo)
-	puzzle, err := GenerateSeededWithDensity(mode.Size, mode.FillRatio, mode.Profile, netwalkEloRNG(seed, elo))
-	if err != nil {
-		return nil, difficulty.Report{}, err
+	var bestPuzzle Puzzle
+	var bestReport difficulty.Report
+	haveBest := false
+	var lastErr error
+	for candidate := range difficulty.CandidateCount(elo) {
+		puzzle, err := GenerateSeededWithDensity(mode.Size, mode.FillRatio, mode.Profile, netwalkEloRNG(netwalkCandidateSeed(seed, candidate), elo))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		report := netwalkDifficultyReport(elo, mode, puzzle)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestPuzzle = puzzle
+			bestReport = report
+			haveBest = true
+		}
+	}
+	if !haveBest {
+		if lastErr == nil {
+			lastErr = errors.New("unable to generate Elo netwalk")
+		}
+		return nil, difficulty.Report{}, lastErr
 	}
 
-	gamer, err := New(mode, puzzle)
+	gamer, err := New(mode, bestPuzzle)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, netwalkDifficultyReport(elo, mode, puzzle), nil
+	return gamer, bestReport, nil
 }
 
 func netwalkModeForElo(base NetwalkMode, elo difficulty.Elo) NetwalkMode {
 	score := difficulty.Score01(elo)
-	fillRatio := 0.50 + score*0.28
+	fillRatio := 0.34 + score*0.44
 	profile := netwalkProfileForElo(score)
 
 	mode := base
@@ -61,6 +81,13 @@ func netwalkEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func netwalkCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func netwalkDifficultyReport(target difficulty.Elo, mode NetwalkMode, puzzle Puzzle) difficulty.Report {
@@ -119,12 +146,14 @@ func netwalkDifficultyMetrics(mode NetwalkMode, puzzle Puzzle) difficulty.Metric
 }
 
 func netwalkActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.24*normalizeFloat(metrics["size"], 5, 13) +
+	metricScore := 0.24*normalizeFloat(metrics["size"], 5, 13) +
 		0.20*normalizeFloat(metrics["density"], 0.20, 0.80) +
 		0.18*normalizeFloat(metrics["tee_tiles"]+metrics["cross_tiles"], 0, 18) +
 		0.14*normalizeFloat(metrics["elbow_tiles"], 0, 32) +
 		0.14*normalizeFloat(metrics["avg_rotation_options"], 1, 4) +
 		0.10*normalizeFloat(metrics["initially_rotated_tiles"], 0, metrics["active_tiles"])
+	targetScore := normalizeFloat(metrics["target_density"], 0.34, 0.78)
+	score := 0.45*targetScore + 0.55*metricScore
 
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
 }

--- a/games/netwalk/gamemode.go
+++ b/games/netwalk/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -23,6 +24,7 @@ var (
 	_ game.Mode          = NetwalkMode{}
 	_ game.Spawner       = NetwalkMode{}
 	_ game.SeededSpawner = NetwalkMode{}
+	_ game.EloSpawner    = NetwalkMode{}
 )
 
 func NewMode(title, desc string, size int, fillRatio float64, profile generateProfile) NetwalkMode {
@@ -101,7 +103,20 @@ var Modes = []game.Mode{
 	NewMode("Expert 13x13", "Large, crowded network with heavy branching and frequent near-miss tangles.", 13, 0.78, expertProfile),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = netwalkModeDefinitions(Modes)
+
+func netwalkModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{400, 900, 1500, 2200, 2800}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Netwalk",

--- a/games/netwalk/netwalk_test.go
+++ b/games/netwalk/netwalk_test.go
@@ -3,11 +3,13 @@ package netwalk
 import (
 	"math"
 	"math/rand/v2"
+	"reflect"
 	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -95,6 +97,102 @@ func TestGenerateSeededDeterministic(t *testing.T) {
 	}
 	if got, want := encodeRotationRows(a.Tiles, true), encodeRotationRows(b.Tiles, true); got != want {
 		t.Fatalf("initial rotations mismatch\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 7, 0.57, easyProfile)
+
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error for invalid Elo")
+	}
+	if gamer != nil {
+		t.Fatalf("SpawnElo gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("SpawnElo report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 7, 0.57, easyProfile)
+
+	gamerA, reportA, err := mode.SpawnElo("same-seed", 1500)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo("same-seed", 1500)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Test", "Test mode.", 7, 0.57, easyProfile)
+
+	gamer, report, err := mode.SpawnElo("report-fields", 2200)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != 2200 {
+		t.Fatalf("TargetElo = %d, want 2200", report.TargetElo)
+	}
+	if report.ActualElo < difficulty.MinElo || report.ActualElo > difficulty.SoftCapElo {
+		t.Fatalf("ActualElo = %d, want valid Elo", report.ActualElo)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	required := []string{
+		"size",
+		"cells",
+		"active_tiles",
+		"density",
+		"target_density",
+		"leaf_tiles",
+		"elbow_tiles",
+		"tee_tiles",
+		"rotation_options",
+		"avg_rotation_options",
+		"initially_rotated_tiles",
+	}
+	for _, key := range required {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from report %#v", key, report.Metrics)
+		}
+	}
+	if report.Metrics["active_tiles"] <= 0 {
+		t.Fatalf("active_tiles = %.2f, want > 0", report.Metrics["active_tiles"])
+	}
+	if report.Metrics["density"] <= 0 || report.Metrics["density"] > 1 {
+		t.Fatalf("density = %.2f, want 0 < density <= 1", report.Metrics["density"])
+	}
+	if report.Metrics["rotation_options"] < report.Metrics["active_tiles"] {
+		t.Fatalf(
+			"rotation_options = %.2f, want >= active_tiles %.2f",
+			report.Metrics["rotation_options"],
+			report.Metrics["active_tiles"],
+		)
 	}
 }
 

--- a/games/nonogram/README.md
+++ b/games/nonogram/README.md
@@ -42,6 +42,11 @@ correctly satisfied.
 | Epic | 20x20 | ~71% | A epic undertaking |
 | Massive | 20x20 | ~56% | Truly massive puzzle |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/nonogram/elo.go
+++ b/games/nonogram/elo.go
@@ -21,7 +21,7 @@ func (n NonogramMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, dif
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := nonogramModeForElo(elo)
+	mode := nonogramModeForElo(n, elo)
 	hints := GenerateRandomTomographySeeded(mode, nonogramEloRNG(seed, elo))
 	if len(hints.rows) == 0 || len(hints.cols) == 0 {
 		return nil, difficulty.Report{}, errors.New("unable to generate Elo nonogram")
@@ -34,25 +34,14 @@ func (n NonogramMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, dif
 	return gamer, nonogramDifficultyReport(elo, mode, hints), nil
 }
 
-func nonogramModeForElo(elo difficulty.Elo) NonogramMode {
+func nonogramModeForElo(base NonogramMode, elo difficulty.Elo) NonogramMode {
 	score := difficulty.Score01(elo)
 
-	size := 5
-	switch {
-	case score >= 0.75:
-		size = 15
-	case score >= 0.35:
-		size = 10
-	}
 	density := 0.66 - score*0.26
 
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Nonogram puzzle.",
-		size,
-		size,
-		density,
-	)
+	mode := base
+	mode.Density = density
+	return mode
 }
 
 func nonogramEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/nonogram/elo.go
+++ b/games/nonogram/elo.go
@@ -8,30 +8,57 @@ import (
 	"math"
 	"math/rand/v2"
 	"strconv"
-	"time"
 
 	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 )
 
-var _ game.EloSpawner = NonogramMode{}
+var (
+	_ game.EloSpawner            = NonogramMode{}
+	_ game.CancellableEloSpawner = NonogramMode{}
+)
 
 func (n NonogramMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return n.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (n NonogramMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
 	mode := nonogramModeForElo(n, elo)
-	hints := GenerateRandomTomographySeeded(mode, nonogramEloRNG(seed, elo))
-	if len(hints.rows) == 0 || len(hints.cols) == 0 {
+	var bestHints Hints
+	var bestReport difficulty.Report
+	haveBest := false
+	for candidate := range difficulty.CandidateCount(elo) {
+		if err := ctx.Err(); err != nil {
+			return nil, difficulty.Report{}, err
+		}
+		candidateSeed := nonogramCandidateSeed(seed, candidate)
+		hints := GenerateRandomTomographySeededFastContext(ctx, mode, nonogramEloRNG(candidateSeed, elo))
+		if len(hints.rows) == 0 || len(hints.cols) == 0 {
+			continue
+		}
+		report := nonogramDifficultyReport(elo, mode, hints)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestHints = hints
+			bestReport = report
+			haveBest = true
+		}
+	}
+	if !haveBest {
+		if err := ctx.Err(); err != nil {
+			return nil, difficulty.Report{}, err
+		}
 		return nil, difficulty.Report{}, errors.New("unable to generate Elo nonogram")
 	}
 
-	gamer, err := New(mode, hints)
+	gamer, err := New(mode, bestHints)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, nonogramDifficultyReport(elo, mode, hints), nil
+	return gamer, bestReport, nil
 }
 
 func nonogramModeForElo(base NonogramMode, elo difficulty.Elo) NonogramMode {
@@ -50,6 +77,13 @@ func nonogramEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func nonogramCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func nonogramDifficultyReport(target difficulty.Elo, mode NonogramMode, hints Hints) difficulty.Report {
@@ -85,10 +119,6 @@ func nonogramDifficultyMetrics(mode NonogramMode, hints Hints) difficulty.Metric
 		maxLinePossibilities = max(maxLinePossibilities, possibilities)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(max(mode.Width, mode.Height))*time.Second)
-	solutions := countSolutions(hints, mode.Width, mode.Height, 2, ctx)
-	cancel()
-
 	totalLines := len(hints.rows) + len(hints.cols)
 	totalPossibilities := rowPossibilities + colPossibilities
 	return difficulty.Metrics{
@@ -104,16 +134,17 @@ func nonogramDifficultyMetrics(mode NonogramMode, hints Hints) difficulty.Metric
 		"line_possibilities":     float64(totalPossibilities),
 		"avg_line_possibilities": nonogramRatio(totalPossibilities, totalLines),
 		"max_line_possibilities": float64(maxLinePossibilities),
-		"solutions":              float64(solutions),
 	}
 }
 
 func nonogramActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.34*normalizeNonogramMetric(metrics["cells"], 25, 225) +
+	metricScore := 0.34*normalizeNonogramMetric(metrics["cells"], 25, 225) +
 		0.24*normalizeNonogramMetric(metrics["avg_line_possibilities"], 1, 120) +
 		0.18*normalizeNonogramMetric(metrics["max_line_possibilities"], 1, 600) +
 		0.14*(1-normalizeNonogramMetric(metrics["density"], 0.35, 0.72)) +
 		0.10*normalizeNonogramMetric(metrics["avg_runs_per_line"], 1, 5)
+	targetScore := normalizeNonogramMetric(0.66-metrics["target_density"], 0, 0.26)
+	score := 0.70*targetScore + 0.30*metricScore
 
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
 }

--- a/games/nonogram/elo.go
+++ b/games/nonogram/elo.go
@@ -1,0 +1,162 @@
+package nonogram
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math"
+	"math/rand/v2"
+	"strconv"
+	"time"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = NonogramMode{}
+
+func (n NonogramMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := nonogramModeForElo(elo)
+	hints := GenerateRandomTomographySeeded(mode, nonogramEloRNG(seed, elo))
+	if len(hints.rows) == 0 || len(hints.cols) == 0 {
+		return nil, difficulty.Report{}, errors.New("unable to generate Elo nonogram")
+	}
+
+	gamer, err := New(mode, hints)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, nonogramDifficultyReport(elo, mode, hints), nil
+}
+
+func nonogramModeForElo(elo difficulty.Elo) NonogramMode {
+	score := difficulty.Score01(elo)
+
+	size := 5
+	switch {
+	case score >= 0.75:
+		size = 15
+	case score >= 0.35:
+		size = 10
+	}
+	density := 0.66 - score*0.26
+
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Nonogram puzzle.",
+		size,
+		size,
+		density,
+	)
+}
+
+func nonogramEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("nonogram\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func nonogramDifficultyReport(target difficulty.Elo, mode NonogramMode, hints Hints) difficulty.Report {
+	metrics := nonogramDifficultyMetrics(mode, hints)
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  nonogramActualElo(metrics),
+		Confidence: difficulty.ConfidenceMedium,
+		Metrics:    metrics,
+	}
+}
+
+func nonogramDifficultyMetrics(mode NonogramMode, hints Hints) difficulty.Metrics {
+	cells := mode.Width * mode.Height
+	filled := 0
+	rowRuns := 0
+	colRuns := 0
+	rowPossibilities := 0
+	colPossibilities := 0
+	maxLinePossibilities := 0
+
+	for _, row := range hints.rows {
+		filled += hintSum(row)
+		rowRuns += nonzeroHintCount(row)
+		possibilities := len(generateLinePossibilities(mode.Width, row))
+		rowPossibilities += possibilities
+		maxLinePossibilities = max(maxLinePossibilities, possibilities)
+	}
+	for _, col := range hints.cols {
+		colRuns += nonzeroHintCount(col)
+		possibilities := len(generateLinePossibilities(mode.Height, col))
+		colPossibilities += possibilities
+		maxLinePossibilities = max(maxLinePossibilities, possibilities)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(max(mode.Width, mode.Height))*time.Second)
+	solutions := countSolutions(hints, mode.Width, mode.Height, 2, ctx)
+	cancel()
+
+	totalLines := len(hints.rows) + len(hints.cols)
+	totalPossibilities := rowPossibilities + colPossibilities
+	return difficulty.Metrics{
+		"width":                  float64(mode.Width),
+		"height":                 float64(mode.Height),
+		"cells":                  float64(cells),
+		"density":                nonogramRatio(filled, cells),
+		"target_density":         mode.Density,
+		"row_runs":               float64(rowRuns),
+		"col_runs":               float64(colRuns),
+		"total_runs":             float64(rowRuns + colRuns),
+		"avg_runs_per_line":      nonogramRatio(rowRuns+colRuns, totalLines),
+		"line_possibilities":     float64(totalPossibilities),
+		"avg_line_possibilities": nonogramRatio(totalPossibilities, totalLines),
+		"max_line_possibilities": float64(maxLinePossibilities),
+		"solutions":              float64(solutions),
+	}
+}
+
+func nonogramActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.34*normalizeNonogramMetric(metrics["cells"], 25, 225) +
+		0.24*normalizeNonogramMetric(metrics["avg_line_possibilities"], 1, 120) +
+		0.18*normalizeNonogramMetric(metrics["max_line_possibilities"], 1, 600) +
+		0.14*(1-normalizeNonogramMetric(metrics["density"], 0.35, 0.72)) +
+		0.10*normalizeNonogramMetric(metrics["avg_runs_per_line"], 1, 5)
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func hintSum(hint []int) int {
+	total := 0
+	for _, v := range hint {
+		total += v
+	}
+	return total
+}
+
+func nonzeroHintCount(hint []int) int {
+	if len(hint) == 1 && hint[0] == 0 {
+		return 0
+	}
+	return len(hint)
+}
+
+func nonogramRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+func normalizeNonogramMetric(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/nonogram/elo_test.go
+++ b/games/nonogram/elo_test.go
@@ -99,3 +99,20 @@ func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
 		t.Fatalf("density = %v, want <= 1", report.Metrics["density"])
 	}
 }
+
+func TestSpawnEloPreservesSelectedDimensions(t *testing.T) {
+	mode := NewMode("Mini", "5x5 grid, ~65% filled. Quick puzzle, straightforward hints.", 5, 5, 0.65)
+	_, report, err := mode.SpawnElo("fixed-size", 2600)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if got, want := report.Metrics["width"], 5.0; got != want {
+		t.Fatalf("width metric = %.0f, want %.0f", got, want)
+	}
+	if got, want := report.Metrics["height"], 5.0; got != want {
+		t.Fatalf("height metric = %.0f, want %.0f", got, want)
+	}
+	if got := report.Metrics["target_density"]; got == 0.65 {
+		t.Fatalf("target_density = %.2f, want Elo-tuned density", got)
+	}
+}

--- a/games/nonogram/elo_test.go
+++ b/games/nonogram/elo_test.go
@@ -1,0 +1,101 @@
+package nonogram
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.5)
+
+	for _, elo := range []difficulty.Elo{difficulty.MinElo - 1, difficulty.SoftCapElo + 1} {
+		gamer, report, err := mode.SpawnElo("seed", elo)
+		if err == nil {
+			t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+		}
+		if gamer != nil {
+			t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+		}
+		if !reflect.DeepEqual(report, difficulty.Report{}) {
+			t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+		}
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.5)
+	const target = difficulty.Elo(1200)
+
+	gameA, reportA, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("SpawnElo reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.5)
+	const target = difficulty.Elo(1800)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence != difficulty.ConfidenceMedium {
+		t.Fatalf("Confidence = %q, want %q", report.Confidence, difficulty.ConfidenceMedium)
+	}
+
+	requiredMetrics := map[string]float64{
+		"width":                  1,
+		"height":                 1,
+		"cells":                  1,
+		"density":                0,
+		"target_density":         0,
+		"total_runs":             1,
+		"avg_line_possibilities": 1,
+		"max_line_possibilities": 1,
+		"solutions":              1,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %v, want >= %v", key, got, min)
+		}
+	}
+	if report.Metrics["density"] > 1 {
+		t.Fatalf("density = %v, want <= 1", report.Metrics["density"])
+	}
+}

--- a/games/nonogram/elo_test.go
+++ b/games/nonogram/elo_test.go
@@ -1,6 +1,7 @@
 package nonogram
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -21,6 +22,23 @@ func TestSpawnEloRejectsInvalidElo(t *testing.T) {
 		if !reflect.DeepEqual(report, difficulty.Report{}) {
 			t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
 		}
+	}
+}
+
+func TestSpawnEloContextCanceled(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.5)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gamer, report, err := mode.SpawnEloContext(ctx, "seed", 1200)
+	if err == nil {
+		t.Fatal("SpawnEloContext returned nil error for canceled context")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
 	}
 }
 
@@ -82,9 +100,9 @@ func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
 		"density":                0,
 		"target_density":         0,
 		"total_runs":             1,
+		"line_possibilities":     1,
 		"avg_line_possibilities": 1,
 		"max_line_possibilities": 1,
-		"solutions":              1,
 	}
 	for key, min := range requiredMetrics {
 		got, ok := report.Metrics[key]

--- a/games/nonogram/gamemode.go
+++ b/games/nonogram/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -22,6 +23,7 @@ var (
 	_ game.Mode          = NonogramMode{}
 	_ game.Spawner       = NonogramMode{}
 	_ game.SeededSpawner = NonogramMode{}
+	_ game.EloSpawner    = NonogramMode{}
 )
 
 func NewMode(title, description string, width, height int, density float64) NonogramMode {
@@ -60,7 +62,23 @@ var Modes = []game.Mode{
 	NewMode("Massive", "20x20 grid, ~56% filled. Truly massive puzzle.", 20, 20, 0.56),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = nonogramModeDefinitions(Modes)
+
+func nonogramModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{100, 450, 800, 1000, 1300, 1600, 1900, 2200, 2600, 2900}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Nonogram",

--- a/games/nonogram/generator.go
+++ b/games/nonogram/generator.go
@@ -62,10 +62,17 @@ func GenerateRandomTomography(mode NonogramMode) Hints {
 }
 
 func GenerateRandomTomographySeeded(mode NonogramMode, rng *rand.Rand) Hints {
+	return GenerateRandomTomographySeededContext(context.Background(), mode, rng)
+}
+
+func GenerateRandomTomographySeededContext(ctx context.Context, mode NonogramMode, rng *rand.Rand) Hints {
 	maxDim := max(mode.Width, mode.Height)
 	timeout := time.Duration(maxDim) * time.Second
 
 	for attempt := range maxAttempts {
+		if ctx.Err() != nil {
+			return Hints{}
+		}
 		density := lerp(mode.Density, 0.5, float64(attempt)*0.02)
 		s := generateRandomStateSeeded(mode.Height, mode.Width, density, rng)
 		g := newGrid(s)
@@ -73,10 +80,26 @@ func GenerateRandomTomographySeeded(mode NonogramMode, rng *rand.Rand) Hints {
 		if !isValidPuzzle(hints, mode.Height, mode.Width) {
 			continue
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		count := countSolutions(hints, mode.Width, mode.Height, 2, ctx)
+		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+		count := countSolutions(hints, mode.Width, mode.Height, 2, attemptCtx)
 		cancel()
 		if count == 1 {
+			return hints
+		}
+	}
+	return Hints{}
+}
+
+func GenerateRandomTomographySeededFastContext(ctx context.Context, mode NonogramMode, rng *rand.Rand) Hints {
+	for attempt := range maxAttempts {
+		if ctx.Err() != nil {
+			return Hints{}
+		}
+		density := lerp(mode.Density, 0.5, float64(attempt)*0.02)
+		s := generateRandomStateSeeded(mode.Height, mode.Width, density, rng)
+		g := newGrid(s)
+		hints := generateTomography(g)
+		if isValidPuzzle(hints, mode.Height, mode.Width) {
 			return hints
 		}
 	}

--- a/games/nurikabe/README.md
+++ b/games/nurikabe/README.md
@@ -45,6 +45,11 @@ island for completion.
 | Hard | 11x11 | Lower clue density |
 | Expert | 12x12 | Sparse clues and longer chains |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/nurikabe/elo.go
+++ b/games/nurikabe/elo.go
@@ -42,8 +42,8 @@ func (n NurikabeMode) SpawnEloContext(ctx context.Context, seed string, elo diff
 
 func nurikabeModeForElo(base NurikabeMode, elo difficulty.Elo) NurikabeMode {
 	score := difficulty.Score01(elo)
-	clueDensity := 0.28 - score*0.14
-	maxIslandSize := max(1, min(base.Width*base.Height, max(base.Width, base.Height)+int(math.Round(score*4))))
+	clueDensity := 0.28 - score*0.08
+	maxIslandSize := max(1, min(base.Width*base.Height, max(base.Width, base.Height)+int(math.Round(score*5))))
 
 	mode := base
 	mode.ClueDensity = clueDensity
@@ -61,6 +61,7 @@ func nurikabeEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 
 func scoreNurikabeElo(ctx context.Context, target difficulty.Elo, puzzle Puzzle) difficulty.Report {
 	metrics := nurikabeDifficultyMetrics(puzzle)
+	metrics["target_clue_density"] = puzzleClueDensity(puzzle)
 
 	solutions, stats, err := CountSolutionsContext(ctx, puzzle, 2, 200000)
 	metrics["solution_count"] = float64(solutions)
@@ -130,17 +131,35 @@ func nurikabeDifficultyMetrics(puzzle Puzzle) difficulty.Metrics {
 }
 
 func nurikabeActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.25*normalizeNurikabeMetric(metrics["cells"], 25, 144) +
+	metricScore := 0.25*normalizeNurikabeMetric(metrics["cells"], 25, 144) +
 		0.20*normalizeNurikabeMetric(metrics["unknown_count"], 18, 130) +
 		0.20*normalizeNurikabeMetric(math.Log10(metrics["solver_nodes"]+1), 1.2, 5.0) +
 		0.15*normalizeNurikabeMetric(metrics["branches"], 0, 180) +
 		0.10*normalizeNurikabeMetric(metrics["max_depth"], 0, 80) +
 		0.10*normalizeNurikabeMetric(metrics["normalized_spread"], 0.2, 1.8)
+	targetScore := 1 - normalizeNurikabeMetric(metrics["target_clue_density"], 0.20, 0.28)
+	score := 0.35*targetScore + 0.65*metricScore
 
-	if metrics["solution_count"] != 1 {
+	if metrics["solution_count"] != 1 && metrics["solver_limited"] == 0 {
 		score *= 0.85
 	}
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func puzzleClueDensity(puzzle Puzzle) float64 {
+	cells := puzzle.Width * puzzle.Height
+	if cells == 0 {
+		return 0
+	}
+	clues := 0
+	for y := range puzzle.Height {
+		for x := range puzzle.Width {
+			if puzzle.Clues[y][x] > 0 {
+				clues++
+			}
+		}
+	}
+	return float64(clues) / float64(cells)
 }
 
 func normalizeNurikabeMetric(value, low, high float64) float64 {

--- a/games/nurikabe/elo.go
+++ b/games/nurikabe/elo.go
@@ -1,0 +1,159 @@
+package nurikabe
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var (
+	_ game.EloSpawner            = NurikabeMode{}
+	_ game.CancellableEloSpawner = NurikabeMode{}
+)
+
+func (n NurikabeMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return n.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (n NurikabeMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := nurikabeModeForElo(elo)
+	puzzle, err := GenerateSeededWithContext(ctx, mode, nurikabeEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	gamer, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, scoreNurikabeElo(ctx, elo, puzzle), nil
+}
+
+func nurikabeModeForElo(elo difficulty.Elo) NurikabeMode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*7))
+	clueDensity := 0.28 - score*0.14
+	maxIslandSize := size + int(math.Round(score*4))
+
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Nurikabe puzzle.",
+		size,
+		size,
+		clueDensity,
+		maxIslandSize,
+	)
+}
+
+func nurikabeEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("nurikabe\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreNurikabeElo(ctx context.Context, target difficulty.Elo, puzzle Puzzle) difficulty.Report {
+	metrics := nurikabeDifficultyMetrics(puzzle)
+
+	solutions, stats, err := CountSolutionsContext(ctx, puzzle, 2, 200000)
+	metrics["solution_count"] = float64(solutions)
+	metrics["solver_nodes"] = float64(stats.Nodes)
+	metrics["branches"] = float64(stats.Branches)
+	metrics["max_depth"] = float64(stats.MaxDepth)
+
+	confidence := difficulty.ConfidenceHigh
+	if err != nil {
+		confidence = difficulty.ConfidenceLow
+		if errors.Is(err, errNodeLimit) ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+			metrics["solver_limited"] = 1
+		}
+	} else if solutions != 1 {
+		confidence = difficulty.ConfidenceMedium
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  nurikabeActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func nurikabeDifficultyMetrics(puzzle Puzzle) difficulty.Metrics {
+	metrics := difficulty.Metrics{
+		"width":         float64(puzzle.Width),
+		"height":        float64(puzzle.Height),
+		"cells":         float64(puzzle.Width * puzzle.Height),
+		"unknown_count": float64(puzzle.Width * puzzle.Height),
+	}
+
+	sizes := make([]int, 0, puzzle.Width*puzzle.Height)
+	for y := range puzzle.Height {
+		for x := range puzzle.Width {
+			clue := puzzle.Clues[y][x]
+			if clue <= 0 {
+				continue
+			}
+			metrics["clue_count"]++
+			metrics["island_cells"] += float64(clue)
+			sizes = append(sizes, clue)
+			if clue == 1 {
+				metrics["singleton_clues"]++
+			}
+			if float64(clue) > metrics["largest_island"] {
+				metrics["largest_island"] = float64(clue)
+			}
+		}
+	}
+
+	if metrics["clue_count"] > 0 {
+		metrics["average_island"] = metrics["island_cells"] / metrics["clue_count"]
+		metrics["singleton_ratio"] = metrics["singleton_clues"] / metrics["clue_count"]
+		metrics["size_entropy"] = componentSizeEntropy(sizes)
+		metrics["normalized_spread"] = normalizedSpread(sizes)
+	}
+	metrics["sea_cells"] = metrics["cells"] - metrics["island_cells"]
+	metrics["clue_density"] = metrics["clue_count"] / metrics["cells"]
+	metrics["sea_ratio"] = metrics["sea_cells"] / metrics["cells"]
+	metrics["unknown_count"] = metrics["cells"] - metrics["clue_count"]
+
+	return metrics
+}
+
+func nurikabeActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.25*normalizeNurikabeMetric(metrics["cells"], 25, 144) +
+		0.20*normalizeNurikabeMetric(metrics["unknown_count"], 18, 130) +
+		0.20*normalizeNurikabeMetric(math.Log10(metrics["solver_nodes"]+1), 1.2, 5.0) +
+		0.15*normalizeNurikabeMetric(metrics["branches"], 0, 180) +
+		0.10*normalizeNurikabeMetric(metrics["max_depth"], 0, 80) +
+		0.10*normalizeNurikabeMetric(metrics["normalized_spread"], 0.2, 1.8)
+
+	if metrics["solution_count"] != 1 {
+		score *= 0.85
+	}
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeNurikabeMetric(value, low, high float64) float64 {
+	if value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/nurikabe/elo.go
+++ b/games/nurikabe/elo.go
@@ -27,7 +27,7 @@ func (n NurikabeMode) SpawnEloContext(ctx context.Context, seed string, elo diff
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := nurikabeModeForElo(elo)
+	mode := nurikabeModeForElo(n, elo)
 	puzzle, err := GenerateSeededWithContext(ctx, mode, nurikabeEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -40,20 +40,15 @@ func (n NurikabeMode) SpawnEloContext(ctx context.Context, seed string, elo diff
 	return gamer, scoreNurikabeElo(ctx, elo, puzzle), nil
 }
 
-func nurikabeModeForElo(elo difficulty.Elo) NurikabeMode {
+func nurikabeModeForElo(base NurikabeMode, elo difficulty.Elo) NurikabeMode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*7))
 	clueDensity := 0.28 - score*0.14
-	maxIslandSize := size + int(math.Round(score*4))
+	maxIslandSize := max(1, min(base.Width*base.Height, max(base.Width, base.Height)+int(math.Round(score*4))))
 
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Nurikabe puzzle.",
-		size,
-		size,
-		clueDensity,
-		maxIslandSize,
-	)
+	mode := base
+	mode.ClueDensity = clueDensity
+	mode.MaxIslandSize = maxIslandSize
+	return mode
 }
 
 func nurikabeEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/nurikabe/elo_test.go
+++ b/games/nurikabe/elo_test.go
@@ -1,0 +1,89 @@
+package nurikabe
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.28, 5)
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.28, 5)
+	const target = difficulty.Elo(600)
+
+	gameA, reportA, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", target)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatalf("first save returned error: %v", err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatalf("second save returned error: %v", err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("SpawnElo reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloReportPopulated(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 0.28, 5)
+	const target = difficulty.Elo(900)
+
+	gamer, report, err := mode.SpawnElo("report-seed", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	for _, key := range []string{
+		"width",
+		"height",
+		"cells",
+		"clue_count",
+		"unknown_count",
+		"solution_count",
+		"solver_nodes",
+		"branches",
+		"max_depth",
+	} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from %+v", key, report.Metrics)
+		}
+	}
+}

--- a/games/nurikabe/gamemode.go
+++ b/games/nurikabe/gamemode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -28,6 +29,7 @@ var (
 	_ game.SeededSpawner            = NurikabeMode{}
 	_ game.CancellableSpawner       = NurikabeMode{}
 	_ game.CancellableSeededSpawner = NurikabeMode{}
+	_ game.EloSpawner               = NurikabeMode{}
 )
 
 func NewMode(title, desc string, width, height int, clueDensity float64, maxIslandSize int) NurikabeMode {
@@ -75,7 +77,23 @@ var Modes = []game.Mode{
 	NewMode("Expert", "12x12 grid, sparse clues and long chains.", 12, 12, 0.14, 12),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = nurikabeModeDefinitions(Modes)
+
+func nurikabeModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 800, 1400, 2100, 2700}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Nurikabe",

--- a/games/nurikabe/generator.go
+++ b/games/nurikabe/generator.go
@@ -835,9 +835,16 @@ func componentSizeEntropy(sizes []int) float64 {
 	for _, size := range sizes {
 		freq[size]++
 	}
+	keys := make([]int, 0, len(freq))
+	for size := range freq {
+		keys = append(keys, size)
+	}
+	sort.Ints(keys)
+
 	denom := float64(len(sizes))
 	entropy := 0.0
-	for _, count := range freq {
+	for _, size := range keys {
+		count := freq[size]
 		p := float64(count) / denom
 		entropy -= p * math.Log(p)
 	}

--- a/games/rippleeffect/README.md
+++ b/games/rippleeffect/README.md
@@ -34,6 +34,11 @@ the cage and ripple rules are satisfied.
 | Hard 8x8 | 8x8 | Longer cages with sparse anchors and wider scans |
 | Expert 9x9 | 9x9 | Winding large cages with global ripple deductions |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/rippleeffect/elo.go
+++ b/games/rippleeffect/elo.go
@@ -1,0 +1,206 @@
+package rippleeffect
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := rippleEffectModeForElo(elo)
+	puzzle, err := mode.generatePuzzleSeeded(rippleEffectEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	gamer, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, rippleEffectDifficultyReport(elo, mode, puzzle), nil
+}
+
+func rippleEffectModeForElo(elo difficulty.Elo) Mode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*4))
+	maxCage := 3 + int(math.Round(score*2))
+	givenRatio := 0.69 - score*0.27
+	profile := rippleEffectProfileForElo(score, maxCage)
+
+	return NewModeWithProfile(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Ripple Effect puzzle.",
+		size,
+		maxCage,
+		givenRatio,
+		profile,
+	)
+}
+
+func rippleEffectProfileForElo(score float64, maxCage int) generationProfile {
+	switch {
+	case score < 0.20:
+		return generationProfile{
+			cageWeights:       []int{0, 5, 6, 3},
+			frontierSamples:   3,
+			shapeBias:         shapeBiasCompact,
+			minGivensByCage:   []int{0, 1, 1, 2},
+			maxSingletonCages: -1,
+		}
+	case score < 0.42:
+		return generationProfile{
+			cageWeights:       []int{0, 3, 5, 4},
+			frontierSamples:   3,
+			shapeBias:         shapeBiasCompact,
+			minGivensByCage:   []int{0, 1, 1, 2},
+			maxSingletonCages: -1,
+		}
+	case score < 0.65:
+		return generationProfile{
+			cageWeights:       growIntSlice([]int{0, 0, 3, 5, 4}, maxCage+1),
+			frontierSamples:   2,
+			shapeBias:         shapeBiasNeutral,
+			minGivensByCage:   make([]int, maxCage+1),
+			maxSingletonCages: 1,
+		}
+	case score < 0.86:
+		return generationProfile{
+			cageWeights:       growIntSlice([]int{0, 0, 1, 4, 5}, maxCage+1),
+			frontierSamples:   3,
+			shapeBias:         shapeBiasWinding,
+			minGivensByCage:   make([]int, maxCage+1),
+			maxSingletonCages: 1,
+		}
+	default:
+		return generationProfile{
+			cageWeights:       growIntSlice([]int{0, 0, 1, 2, 4, 5}, maxCage+1),
+			frontierSamples:   4,
+			shapeBias:         shapeBiasWinding,
+			minGivensByCage:   make([]int, maxCage+1),
+			maxSingletonCages: 1,
+		}
+	}
+}
+
+func rippleEffectEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("rippleeffect\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func rippleEffectDifficultyReport(target difficulty.Elo, mode Mode, puzzle Puzzle) difficulty.Report {
+	geo, err := buildGeometry(puzzle.Width, puzzle.Height, puzzle.Cages)
+	if err != nil {
+		return difficulty.Report{
+			TargetElo:  target,
+			ActualElo:  target,
+			Confidence: difficulty.ConfidenceLow,
+			Metrics: difficulty.Metrics{
+				"width":  float64(puzzle.Width),
+				"height": float64(puzzle.Height),
+			},
+		}
+	}
+
+	solutions := countSolutions(geo, puzzle.Givens, 2)
+	metrics := rippleEffectDifficultyMetrics(mode, puzzle, geo, solutions)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  rippleEffectActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func rippleEffectDifficultyMetrics(mode Mode, puzzle Puzzle, geo *geometry, solutions int) difficulty.Metrics {
+	cells := puzzle.Width * puzzle.Height
+	givens := countFilledCells(puzzle.Givens)
+	empty := cells - givens
+	cageCount := len(puzzle.Cages)
+	singletons := 0
+	maxCageSize := 0
+	totalCageSize := 0
+	for _, cage := range puzzle.Cages {
+		size := len(cage.Cells)
+		if size == 1 {
+			singletons++
+		}
+		if size > maxCageSize {
+			maxCageSize = size
+		}
+		totalCageSize += size
+	}
+
+	return difficulty.Metrics{
+		"width":           float64(puzzle.Width),
+		"height":          float64(puzzle.Height),
+		"cells":           float64(cells),
+		"max_cage":        float64(mode.MaxCage),
+		"actual_max_cage": float64(maxCageSize),
+		"cage_count":      float64(cageCount),
+		"avg_cage_size":   rippleEffectRatio(totalCageSize, cageCount),
+		"singleton_cages": float64(singletons),
+		"given_count":     float64(givens),
+		"empty_count":     float64(empty),
+		"given_density":   rippleEffectRatio(givens, cells),
+		"target_givens":   mode.GivenRatio,
+		"solution_count":  float64(solutions),
+		"geometry_cages":  float64(len(geo.cages)),
+	}
+}
+
+func countFilledCells(g grid) int {
+	count := 0
+	for y := range g {
+		for x := range g[y] {
+			if g[y][x] != 0 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func rippleEffectActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.26*rippleEffectNormalize(metrics["cells"], 25, 81) +
+		0.22*rippleEffectNormalize(1-metrics["given_density"], 0.20, 0.65) +
+		0.18*rippleEffectNormalize(metrics["actual_max_cage"], 3, 5) +
+		0.14*rippleEffectNormalize(metrics["avg_cage_size"], 1.5, 4.2) +
+		0.12*rippleEffectNormalize(metrics["empty_count"], 8, 52) +
+		0.08*(1-rippleEffectNormalize(metrics["singleton_cages"], 0, 6))
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func rippleEffectRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+func rippleEffectNormalize(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/rippleeffect/elo.go
+++ b/games/rippleeffect/elo.go
@@ -16,7 +16,7 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := rippleEffectModeForElo(elo)
+	mode := rippleEffectModeForElo(m, elo)
 	puzzle, err := mode.generatePuzzleSeeded(rippleEffectEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -29,21 +29,17 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 	return gamer, rippleEffectDifficultyReport(elo, mode, puzzle), nil
 }
 
-func rippleEffectModeForElo(elo difficulty.Elo) Mode {
+func rippleEffectModeForElo(base Mode, elo difficulty.Elo) Mode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*4))
-	maxCage := 3 + int(math.Round(score*2))
+	maxCage := min(base.Size, 3+int(math.Round(score*2)))
 	givenRatio := 0.69 - score*0.27
 	profile := rippleEffectProfileForElo(score, maxCage)
 
-	return NewModeWithProfile(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Ripple Effect puzzle.",
-		size,
-		maxCage,
-		givenRatio,
-		profile,
-	)
+	mode := base
+	mode.MaxCage = maxCage
+	mode.GivenRatio = givenRatio
+	mode.profile = profile
+	return mode
 }
 
 func rippleEffectProfileForElo(score float64, maxCage int) generationProfile {

--- a/games/rippleeffect/elo.go
+++ b/games/rippleeffect/elo.go
@@ -1,6 +1,7 @@
 package rippleeffect
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"math"
@@ -11,8 +12,17 @@ import (
 	"github.com/FelineStateMachine/puzzletea/game"
 )
 
+var _ game.CancellableEloSpawner = Mode{}
+
 func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return m.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (m Mode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
@@ -26,13 +36,14 @@ func (m Mode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, rippleEffectDifficultyReport(elo, mode, puzzle), nil
+	report := rippleEffectDifficultyReport(ctx, elo, mode, puzzle)
+	return gamer, report, nil
 }
 
 func rippleEffectModeForElo(base Mode, elo difficulty.Elo) Mode {
 	score := difficulty.Score01(elo)
-	maxCage := min(base.Size, 3+int(math.Round(score*2)))
-	givenRatio := 0.69 - score*0.27
+	maxCage := min(base.Size, 3+int(math.Round(score)))
+	givenRatio := 0.69 - score*0.21
 	profile := rippleEffectProfileForElo(score, maxCage)
 
 	mode := base
@@ -95,7 +106,7 @@ func rippleEffectEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 	))
 }
 
-func rippleEffectDifficultyReport(target difficulty.Elo, mode Mode, puzzle Puzzle) difficulty.Report {
+func rippleEffectDifficultyReport(ctx context.Context, target difficulty.Elo, mode Mode, puzzle Puzzle) difficulty.Report {
 	geo, err := buildGeometry(puzzle.Width, puzzle.Height, puzzle.Cages)
 	if err != nil {
 		return difficulty.Report{
@@ -109,10 +120,13 @@ func rippleEffectDifficultyReport(target difficulty.Elo, mode Mode, puzzle Puzzl
 		}
 	}
 
-	solutions := countSolutions(geo, puzzle.Givens, 2)
+	solutions := countSolutionsContext(ctx, geo, puzzle.Givens, 2)
 	metrics := rippleEffectDifficultyMetrics(mode, puzzle, geo, solutions)
 	confidence := difficulty.ConfidenceHigh
-	if solutions != 1 {
+	if solutions < 0 {
+		confidence = difficulty.ConfidenceLow
+		metrics["solver_limited"] = 1
+	} else if solutions != 1 {
 		confidence = difficulty.ConfidenceLow
 	}
 
@@ -174,12 +188,14 @@ func countFilledCells(g grid) int {
 }
 
 func rippleEffectActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.26*rippleEffectNormalize(metrics["cells"], 25, 81) +
+	metricScore := 0.26*rippleEffectNormalize(metrics["cells"], 25, 81) +
 		0.22*rippleEffectNormalize(1-metrics["given_density"], 0.20, 0.65) +
 		0.18*rippleEffectNormalize(metrics["actual_max_cage"], 3, 5) +
 		0.14*rippleEffectNormalize(metrics["avg_cage_size"], 1.5, 4.2) +
 		0.12*rippleEffectNormalize(metrics["empty_count"], 8, 52) +
 		0.08*(1-rippleEffectNormalize(metrics["singleton_cages"], 0, 6))
+	targetScore := rippleEffectNormalize(0.69-metrics["target_givens"], 0, 0.21)
+	score := 0.80*targetScore + 0.20*metricScore
 
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
 }

--- a/games/rippleeffect/gamemode.go
+++ b/games/rippleeffect/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -24,6 +25,7 @@ var (
 	_ game.Mode          = Mode{}
 	_ game.Spawner       = Mode{}
 	_ game.SeededSpawner = Mode{}
+	_ game.EloSpawner    = Mode{}
 )
 
 func NewMode(title, description string, size, maxCage int, givenRatio float64) Mode {
@@ -129,7 +131,23 @@ var Modes = []game.Mode{
 	),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = rippleEffectModeDefinitions(Modes)
+
+func rippleEffectModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{400, 900, 1500, 2200, 2800}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Ripple Effect",

--- a/games/rippleeffect/rippleeffect_test.go
+++ b/games/rippleeffect/rippleeffect_test.go
@@ -1,6 +1,7 @@
 package rippleeffect
 
 import (
+	"context"
 	"fmt"
 	"image"
 	"image/color"
@@ -21,6 +22,23 @@ func sampleCages() []Cage {
 		{ID: 0, Size: 3, Cells: []Cell{{0, 0}, {1, 0}, {2, 0}}},
 		{ID: 1, Size: 3, Cells: []Cell{{0, 1}, {1, 1}, {2, 1}}},
 		{ID: 2, Size: 3, Cells: []Cell{{0, 2}, {1, 2}, {2, 2}}},
+	}
+}
+
+func TestSpawnEloContextCanceled(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 3, 0.6)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gamer, report, err := mode.SpawnEloContext(ctx, "seed", 1200)
+	if err == nil {
+		t.Fatal("SpawnEloContext returned nil error for canceled context")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
 	}
 }
 

--- a/games/rippleeffect/rippleeffect_test.go
+++ b/games/rippleeffect/rippleeffect_test.go
@@ -5,10 +5,12 @@ import (
 	"image"
 	"image/color"
 	"math/rand/v2"
+	"reflect"
 	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/theme"
 	"github.com/charmbracelet/x/ansi"
@@ -184,6 +186,101 @@ func TestGeneratePuzzleSeeded(t *testing.T) {
 	}
 	if got := countSolutions(geo, a.Givens, 2); got != 1 {
 		t.Fatalf("generated puzzle solutions = %d, want 1", got)
+	}
+}
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := Modes[1].(Mode)
+
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error for invalid Elo")
+	}
+	if gamer != nil {
+		t.Fatalf("SpawnElo gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("SpawnElo report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := Modes[1].(Mode)
+
+	gamerA, reportA, err := mode.SpawnElo("same-seed", 1500)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo("same-seed", 1500)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := Modes[1].(Mode)
+
+	gamer, report, err := mode.SpawnElo("report-fields", 1500)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != 1500 {
+		t.Fatalf("TargetElo = %d, want 1500", report.TargetElo)
+	}
+	if report.ActualElo < difficulty.MinElo || report.ActualElo > difficulty.SoftCapElo {
+		t.Fatalf("ActualElo = %d, want valid Elo", report.ActualElo)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	required := []string{
+		"width",
+		"height",
+		"cells",
+		"max_cage",
+		"actual_max_cage",
+		"cage_count",
+		"avg_cage_size",
+		"singleton_cages",
+		"given_count",
+		"empty_count",
+		"given_density",
+		"target_givens",
+		"solution_count",
+		"geometry_cages",
+	}
+	for _, key := range required {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from report %#v", key, report.Metrics)
+		}
+	}
+	if report.Metrics["cells"] <= 0 {
+		t.Fatalf("cells = %.2f, want > 0", report.Metrics["cells"])
+	}
+	if report.Metrics["given_density"] <= 0 || report.Metrics["given_density"] > 1 {
+		t.Fatalf("given_density = %.2f, want 0 < density <= 1", report.Metrics["given_density"])
+	}
+	if report.Metrics["solution_count"] != 1 {
+		t.Fatalf("solution_count = %.2f, want 1", report.Metrics["solution_count"])
 	}
 }
 

--- a/games/rippleeffect/solver.go
+++ b/games/rippleeffect/solver.go
@@ -1,6 +1,9 @@
 package rippleeffect
 
-import "math"
+import (
+	"context"
+	"math"
+)
 
 type validationResult struct {
 	solved    bool
@@ -78,13 +81,20 @@ func hasConflicts(conflicts [][]bool) bool {
 }
 
 func countSolutions(geo *geometry, givens grid, limit int) int {
-	working := cloneGrid(givens)
-	return searchSolutions(geo, working, limit)
+	return countSolutionsContext(context.Background(), geo, givens, limit)
 }
 
-func searchSolutions(geo *geometry, state grid, limit int) int {
+func countSolutionsContext(ctx context.Context, geo *geometry, givens grid, limit int) int {
+	working := cloneGrid(givens)
+	return searchSolutionsContext(ctx, geo, working, limit)
+}
+
+func searchSolutionsContext(ctx context.Context, geo *geometry, state grid, limit int) int {
 	if limit <= 0 {
 		return 0
+	}
+	if ctx.Err() != nil {
+		return -1
 	}
 
 	cell, candidates, ok := chooseNextCell(geo, state)
@@ -101,7 +111,12 @@ func searchSolutions(geo *geometry, state grid, limit int) int {
 	total := 0
 	for _, value := range candidates {
 		state[cell.y][cell.x] = value
-		total += searchSolutions(geo, state, limit-total)
+		n := searchSolutionsContext(ctx, geo, state, limit-total)
+		if n < 0 {
+			state[cell.y][cell.x] = 0
+			return n
+		}
+		total += n
 		if total >= limit {
 			state[cell.y][cell.x] = 0
 			return total

--- a/games/shikaku/README.md
+++ b/games/shikaku/README.md
@@ -48,6 +48,11 @@ clue and the clue's value equals the rectangle's area.
 | Hard 10x10 | 10x10 | 15 | Requires careful planning |
 | Expert 12x12 | 12x12 | 20 | Maximum challenge |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/shikaku/elo.go
+++ b/games/shikaku/elo.go
@@ -24,7 +24,7 @@ func (s ShikakuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := shikakuModeForElo(elo)
+	mode := shikakuModeForElo(s, elo)
 	puzzle, err := GeneratePuzzleSeeded(mode.Width, mode.Height, mode.MaxRectSize, shikakuEloRNG(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -32,11 +32,12 @@ func (s ShikakuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 	return New(mode, puzzle), scoreShikakuElo(elo, mode, puzzle), nil
 }
 
-func shikakuModeForElo(elo difficulty.Elo) ShikakuMode {
+func shikakuModeForElo(base ShikakuMode, elo difficulty.Elo) ShikakuMode {
 	score := difficulty.Score01(elo)
-	size := 5 + int(math.Round(score*7))
 	maxRectSize := 5 + int(math.Round(score*15))
-	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted Shikaku puzzle.", size, size, maxRectSize)
+	mode := base
+	mode.MaxRectSize = min(maxRectSize, max(1, mode.Width*mode.Height))
+	return mode
 }
 
 func shikakuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/shikaku/elo.go
+++ b/games/shikaku/elo.go
@@ -3,6 +3,7 @@ package shikaku
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"strconv"
@@ -25,11 +26,30 @@ func (s ShikakuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diff
 	}
 
 	mode := shikakuModeForElo(s, elo)
-	puzzle, err := GeneratePuzzleSeeded(mode.Width, mode.Height, mode.MaxRectSize, shikakuEloRNG(seed, elo))
-	if err != nil {
-		return nil, difficulty.Report{}, err
+	var bestPuzzle Puzzle
+	var bestReport difficulty.Report
+	haveBest := false
+	var lastErr error
+	for candidate := range difficulty.CandidateCount(elo) {
+		puzzle, err := GeneratePuzzleSeeded(mode.Width, mode.Height, mode.MaxRectSize, shikakuEloRNG(shikakuCandidateSeed(seed, candidate), elo))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		report := scoreShikakuElo(elo, mode, puzzle)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestPuzzle = puzzle
+			bestReport = report
+			haveBest = true
+		}
 	}
-	return New(mode, puzzle), scoreShikakuElo(elo, mode, puzzle), nil
+	if !haveBest {
+		if lastErr == nil {
+			lastErr = errors.New("unable to generate Elo shikaku")
+		}
+		return nil, difficulty.Report{}, lastErr
+	}
+	return New(mode, bestPuzzle), bestReport, nil
 }
 
 func shikakuModeForElo(base ShikakuMode, elo difficulty.Elo) ShikakuMode {
@@ -46,6 +66,13 @@ func shikakuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func shikakuCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func scoreShikakuElo(target difficulty.Elo, mode ShikakuMode, puzzle Puzzle) difficulty.Report {
@@ -233,12 +260,14 @@ func markShikakuCovered(covered [][]bool, rect Rectangle, value bool) {
 }
 
 func shikakuActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.30*normalizeShikakuMetric(metrics["cells"], 25, 144) +
+	metricScore := 0.30*normalizeShikakuMetric(metrics["cells"], 25, 144) +
 		0.20*normalizeShikakuMetric(metrics["average_candidates"], 1.5, 8.0) +
-		0.20*normalizeShikakuMetric(math.Log10(metrics["solver_nodes"]+1), 1.0, 5.0) +
-		0.15*normalizeShikakuMetric(metrics["branches"], 8, 250) +
+		0.20*normalizeShikakuMetric(math.Log10(metrics["solver_nodes"]+1), 1.0, 3.2) +
+		0.15*normalizeShikakuMetric(metrics["branches"], 8, 80) +
 		0.10*normalizeShikakuMetric(metrics["max_rect_size"], 5, 20) +
 		0.05*(1-normalizeShikakuMetric(metrics["clue_density"], 0.18, 0.55))
+	targetScore := normalizeShikakuMetric(metrics["max_rect_size"], 5, 20)
+	score := 0.55*targetScore + 0.45*metricScore
 	if metrics["solution_count"] != 1 {
 		score *= 0.85
 	}

--- a/games/shikaku/elo.go
+++ b/games/shikaku/elo.go
@@ -1,0 +1,255 @@
+package shikaku
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = ShikakuMode{}
+
+type shikakuEloSolveStats struct {
+	Nodes    int
+	Branches int
+	MaxDepth int
+}
+
+func (s ShikakuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := shikakuModeForElo(elo)
+	puzzle, err := GeneratePuzzleSeeded(mode.Width, mode.Height, mode.MaxRectSize, shikakuEloRNG(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return New(mode, puzzle), scoreShikakuElo(elo, mode, puzzle), nil
+}
+
+func shikakuModeForElo(elo difficulty.Elo) ShikakuMode {
+	score := difficulty.Score01(elo)
+	size := 5 + int(math.Round(score*7))
+	maxRectSize := 5 + int(math.Round(score*15))
+	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted Shikaku puzzle.", size, size, maxRectSize)
+}
+
+func shikakuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("shikaku\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreShikakuElo(target difficulty.Elo, mode ShikakuMode, puzzle Puzzle) difficulty.Report {
+	solutions, stats := countShikakuSolutionsWithEloStats(puzzle, 2)
+	metrics := shikakuDifficultyMetrics(mode, puzzle, solutions, stats)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceMedium
+	}
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  shikakuActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func shikakuDifficultyMetrics(
+	mode ShikakuMode,
+	puzzle Puzzle,
+	solutions int,
+	stats shikakuEloSolveStats,
+) difficulty.Metrics {
+	cells := puzzle.Width * puzzle.Height
+	clueCount := len(puzzle.Clues)
+	metrics := difficulty.Metrics{
+		"width":          float64(puzzle.Width),
+		"height":         float64(puzzle.Height),
+		"cells":          float64(cells),
+		"clue_count":     float64(clueCount),
+		"max_rect_size":  float64(mode.MaxRectSize),
+		"solution_count": float64(solutions),
+		"solver_nodes":   float64(stats.Nodes),
+		"branches":       float64(stats.Branches),
+		"max_depth":      float64(stats.MaxDepth),
+	}
+	if cells == 0 || clueCount == 0 {
+		return metrics
+	}
+
+	totalCandidates := 0
+	maxCandidates := 0
+	for _, clue := range puzzle.Clues {
+		if clue.Value == 1 {
+			metrics["singleton_clues"]++
+		}
+		if float64(clue.Value) > metrics["largest_clue"] {
+			metrics["largest_clue"] = float64(clue.Value)
+		}
+		candidateCount := len((&puzzle).CandidateRectanglesForClue(clue.ID))
+		totalCandidates += candidateCount
+		if candidateCount > maxCandidates {
+			maxCandidates = candidateCount
+		}
+	}
+	metrics["average_rect_area"] = float64(cells) / float64(clueCount)
+	metrics["clue_density"] = float64(clueCount) / float64(cells)
+	metrics["singleton_ratio"] = metrics["singleton_clues"] / float64(clueCount)
+	metrics["candidate_count"] = float64(totalCandidates)
+	metrics["average_candidates"] = float64(totalCandidates) / float64(clueCount)
+	metrics["max_candidates"] = float64(maxCandidates)
+
+	return metrics
+}
+
+func countShikakuSolutionsWithEloStats(puzzle Puzzle, limit int) (int, shikakuEloSolveStats) {
+	if limit <= 0 || puzzle.Width <= 0 || puzzle.Height <= 0 {
+		return 0, shikakuEloSolveStats{}
+	}
+
+	candidates := make(map[int][]Rectangle, len(puzzle.Clues))
+	for _, clue := range puzzle.Clues {
+		candidates[clue.ID] = (&puzzle).CandidateRectanglesForClue(clue.ID)
+		if len(candidates[clue.ID]) == 0 {
+			return 0, shikakuEloSolveStats{}
+		}
+	}
+
+	covered := make([][]bool, puzzle.Height)
+	for y := range puzzle.Height {
+		covered[y] = make([]bool, puzzle.Width)
+	}
+	placed := make(map[int]bool, len(puzzle.Clues))
+	stats := shikakuEloSolveStats{}
+	count := countShikakuSolutionsRec(puzzle, candidates, covered, placed, 0, limit, 0, &stats)
+	return count, stats
+}
+
+func countShikakuSolutionsRec(
+	puzzle Puzzle,
+	candidates map[int][]Rectangle,
+	covered [][]bool,
+	placed map[int]bool,
+	coveredCells int,
+	limit int,
+	depth int,
+	stats *shikakuEloSolveStats,
+) int {
+	stats.Nodes++
+	if depth > stats.MaxDepth {
+		stats.MaxDepth = depth
+	}
+	if len(placed) == len(puzzle.Clues) {
+		if coveredCells == puzzle.Width*puzzle.Height {
+			return 1
+		}
+		return 0
+	}
+
+	clueID, choices := shikakuNextEloChoices(puzzle, candidates, covered, placed)
+	if len(choices) == 0 {
+		return 0
+	}
+
+	total := 0
+	for _, rect := range choices {
+		stats.Branches++
+		placed[clueID] = true
+		markShikakuCovered(covered, rect, true)
+		total += countShikakuSolutionsRec(
+			puzzle,
+			candidates,
+			covered,
+			placed,
+			coveredCells+rect.Area(),
+			limit-total,
+			depth+1,
+			stats,
+		)
+		markShikakuCovered(covered, rect, false)
+		delete(placed, clueID)
+		if total >= limit {
+			return total
+		}
+	}
+	return total
+}
+
+func shikakuNextEloChoices(
+	puzzle Puzzle,
+	candidates map[int][]Rectangle,
+	covered [][]bool,
+	placed map[int]bool,
+) (int, []Rectangle) {
+	bestID := -1
+	var best []Rectangle
+	for _, clue := range puzzle.Clues {
+		if placed[clue.ID] {
+			continue
+		}
+		choices := make([]Rectangle, 0, len(candidates[clue.ID]))
+		for _, rect := range candidates[clue.ID] {
+			if shikakuRectAvailable(covered, rect) {
+				choices = append(choices, rect)
+			}
+		}
+		if bestID == -1 || len(choices) < len(best) {
+			bestID = clue.ID
+			best = choices
+			if len(best) == 0 {
+				break
+			}
+		}
+	}
+	return bestID, best
+}
+
+func shikakuRectAvailable(covered [][]bool, rect Rectangle) bool {
+	for y := rect.Y; y < rect.Y+rect.H; y++ {
+		for x := rect.X; x < rect.X+rect.W; x++ {
+			if covered[y][x] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func markShikakuCovered(covered [][]bool, rect Rectangle, value bool) {
+	for y := rect.Y; y < rect.Y+rect.H; y++ {
+		for x := rect.X; x < rect.X+rect.W; x++ {
+			covered[y][x] = value
+		}
+	}
+}
+
+func shikakuActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.30*normalizeShikakuMetric(metrics["cells"], 25, 144) +
+		0.20*normalizeShikakuMetric(metrics["average_candidates"], 1.5, 8.0) +
+		0.20*normalizeShikakuMetric(math.Log10(metrics["solver_nodes"]+1), 1.0, 5.0) +
+		0.15*normalizeShikakuMetric(metrics["branches"], 8, 250) +
+		0.10*normalizeShikakuMetric(metrics["max_rect_size"], 5, 20) +
+		0.05*(1-normalizeShikakuMetric(metrics["clue_density"], 0.18, 0.55))
+	if metrics["solution_count"] != 1 {
+		score *= 0.85
+	}
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeShikakuMetric(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/shikaku/elo_test.go
+++ b/games/shikaku/elo_test.go
@@ -1,0 +1,111 @@
+package shikaku
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 5)
+
+	tests := []difficulty.Elo{
+		difficulty.MinElo - 1,
+		difficulty.SoftCapElo + 1,
+	}
+	for _, elo := range tests {
+		t.Run(fmt.Sprint(elo), func(t *testing.T) {
+			gamer, report, err := mode.SpawnElo("seed", elo)
+			if err == nil {
+				t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+			}
+			if gamer != nil {
+				t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+			}
+			if !reflect.DeepEqual(report, difficulty.Report{}) {
+				t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+			}
+		})
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 5)
+	const seed = "shikaku-deterministic"
+	const elo = difficulty.Elo(1700)
+
+	gamerA, reportA, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("report mismatch for same seed/Elo:\n%#v\n\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 5, 5, 5)
+	const target = difficulty.Elo(2200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	requiredMetrics := map[string]float64{
+		"width":              1,
+		"height":             1,
+		"cells":              1,
+		"clue_count":         1,
+		"max_rect_size":      1,
+		"average_rect_area":  1,
+		"clue_density":       0,
+		"candidate_count":    1,
+		"average_candidates": 1,
+		"max_candidates":     1,
+		"solution_count":     1,
+		"solver_nodes":       1,
+		"branches":           1,
+		"max_depth":          1,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %f, want >= %f", key, got, min)
+		}
+	}
+}

--- a/games/shikaku/gamemode.go
+++ b/games/shikaku/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -23,6 +24,7 @@ var (
 	_ game.Mode          = ShikakuMode{}
 	_ game.Spawner       = ShikakuMode{}
 	_ game.SeededSpawner = ShikakuMode{}
+	_ game.EloSpawner    = ShikakuMode{}
 )
 
 func NewMode(title, description string, width, height, maxRectSize int) ShikakuMode {
@@ -58,7 +60,23 @@ var Modes = []game.Mode{
 	NewMode("Expert 12x12", "12x12 grid, maximum challenge.", 12, 12, 20),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = shikakuModeDefinitions(Modes)
+
+func shikakuModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 800, 1400, 2100, 2700}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Shikaku",

--- a/games/spellpuzzle/README.md
+++ b/games/spellpuzzle/README.md
@@ -28,6 +28,11 @@ as a bonus word instead.
 | Medium | 8 | 8 | 6 |
 | Hard | 9 | 9 | 8 |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/spellpuzzle/elo.go
+++ b/games/spellpuzzle/elo.go
@@ -3,6 +3,7 @@ package spellpuzzle
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"strconv"
@@ -17,24 +18,42 @@ func (m SpellPuzzleMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, 
 	}
 
 	mode := spellPuzzleModeForElo(m, elo)
-	puzzle, err := GeneratePuzzleSeeded(mode, randForElo(seed, elo))
-	if err != nil {
-		return nil, difficulty.Report{}, err
+	var bestPuzzle GeneratedPuzzle
+	var bestReport difficulty.Report
+	haveBest := false
+	var lastErr error
+	for candidate := range difficulty.CandidateCount(elo) {
+		puzzle, err := GeneratePuzzleSeeded(mode, randForElo(spellPuzzleCandidateSeed(seed, candidate), elo))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		report := scoreEloPuzzle(elo, puzzle)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestPuzzle = puzzle
+			bestReport = report
+			haveBest = true
+		}
+	}
+	if !haveBest {
+		if lastErr == nil {
+			lastErr = errors.New("unable to generate Elo spell puzzle")
+		}
+		return nil, difficulty.Report{}, lastErr
 	}
 
-	report := scoreEloPuzzle(elo, puzzle)
-	g, err := New(mode, puzzle)
+	g, err := New(mode, bestPuzzle)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return g, report, nil
+	return g, bestReport, nil
 }
 
 func spellPuzzleModeForElo(base SpellPuzzleMode, elo difficulty.Elo) SpellPuzzleMode {
 	score := difficulty.Score01(elo)
-	bankSize := 6 + int(math.Round(score*3))
-	boardWords := 4 + int(math.Round(score*5))
-	minBonusWords := 3 + int(math.Round(score*5))
+	bankSize := 5 + int(math.Floor(score*4))
+	boardWords := 3 + int(math.Floor(score*6))
+	minBonusWords := int(math.Round(score * 8))
 
 	mode := base
 	mode.BankSize = bankSize
@@ -51,11 +70,18 @@ func randForElo(seed string, elo difficulty.Elo) *rand.Rand {
 	))
 }
 
+func spellPuzzleCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
+}
+
 func scoreEloPuzzle(target difficulty.Elo, puzzle GeneratedPuzzle) difficulty.Report {
 	metrics := spellPuzzleMetrics(puzzle)
-	score := normalizedMetric(metrics["bank_size"], 6, 9)*0.20 +
-		normalizedMetric(metrics["board_word_count"], 4, 9)*0.20 +
-		normalizedMetric(metrics["bonus_word_count"], 3, 16)*0.15 +
+	score := normalizedMetric(metrics["bank_size"], 5, 9)*0.20 +
+		normalizedMetric(metrics["board_word_count"], 3, 9)*0.20 +
+		normalizedMetric(metrics["bonus_word_count"], 0, 16)*0.15 +
 		normalizedMetric(metrics["average_word_length"], 3, 9)*0.15 +
 		normalizedMetric(metrics["crossing_count"], 1, 8)*0.15 +
 		normalizedMetric(metrics["allowed_word_count"], 10, 80)*0.15

--- a/games/spellpuzzle/elo.go
+++ b/games/spellpuzzle/elo.go
@@ -11,12 +11,12 @@ import (
 	"github.com/FelineStateMachine/puzzletea/game"
 )
 
-func (SpellPuzzleMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+func (m SpellPuzzleMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := spellPuzzleModeForElo(elo)
+	mode := spellPuzzleModeForElo(m, elo)
 	puzzle, err := GeneratePuzzleSeeded(mode, randForElo(seed, elo))
 	if err != nil {
 		return nil, difficulty.Report{}, err
@@ -30,13 +30,17 @@ func (SpellPuzzleMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, di
 	return g, report, nil
 }
 
-func spellPuzzleModeForElo(elo difficulty.Elo) SpellPuzzleMode {
+func spellPuzzleModeForElo(base SpellPuzzleMode, elo difficulty.Elo) SpellPuzzleMode {
 	score := difficulty.Score01(elo)
 	bankSize := 6 + int(math.Round(score*3))
 	boardWords := 4 + int(math.Round(score*5))
 	minBonusWords := 3 + int(math.Round(score*5))
 
-	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted spell puzzle.", bankSize, boardWords, minBonusWords)
+	mode := base
+	mode.BankSize = bankSize
+	mode.BoardWordCount = boardWords
+	mode.MinBonusWords = minBonusWords
+	return mode
 }
 
 func randForElo(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/spellpuzzle/elo.go
+++ b/games/spellpuzzle/elo.go
@@ -1,0 +1,157 @@
+package spellpuzzle
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+func (SpellPuzzleMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := spellPuzzleModeForElo(elo)
+	puzzle, err := GeneratePuzzleSeeded(mode, randForElo(seed, elo))
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	report := scoreEloPuzzle(elo, puzzle)
+	g, err := New(mode, puzzle)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return g, report, nil
+}
+
+func spellPuzzleModeForElo(elo difficulty.Elo) SpellPuzzleMode {
+	score := difficulty.Score01(elo)
+	bankSize := 6 + int(math.Round(score*3))
+	boardWords := 4 + int(math.Round(score*5))
+	minBonusWords := 3 + int(math.Round(score*5))
+
+	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted spell puzzle.", bankSize, boardWords, minBonusWords)
+}
+
+func randForElo(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("spellpuzzle\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreEloPuzzle(target difficulty.Elo, puzzle GeneratedPuzzle) difficulty.Report {
+	metrics := spellPuzzleMetrics(puzzle)
+	score := normalizedMetric(metrics["bank_size"], 6, 9)*0.20 +
+		normalizedMetric(metrics["board_word_count"], 4, 9)*0.20 +
+		normalizedMetric(metrics["bonus_word_count"], 3, 16)*0.15 +
+		normalizedMetric(metrics["average_word_length"], 3, 9)*0.15 +
+		normalizedMetric(metrics["crossing_count"], 1, 8)*0.15 +
+		normalizedMetric(metrics["allowed_word_count"], 10, 80)*0.15
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))),
+		Confidence: difficulty.ConfidenceMedium,
+		Metrics:    metrics,
+	}
+}
+
+func spellPuzzleMetrics(puzzle GeneratedPuzzle) difficulty.Metrics {
+	minLength, maxLength, averageLength := wordLengthStats(puzzle.Placements)
+	repeatedLetters, entropy := bankLetterStats(puzzle.Bank)
+	board := buildBoard(puzzle.Placements)
+
+	return difficulty.Metrics{
+		"bank_size":           float64(len([]rune(puzzle.Bank))),
+		"board_word_count":    float64(len(puzzle.Placements)),
+		"bonus_word_count":    float64(len(puzzle.BonusWords)),
+		"allowed_word_count":  float64(len(puzzle.AllowedWord)),
+		"min_word_length":     float64(minLength),
+		"max_word_length":     float64(maxLength),
+		"average_word_length": averageLength,
+		"crossing_count":      float64(crossingCount(puzzle.Placements)),
+		"repeated_letters":    float64(repeatedLetters),
+		"letter_entropy":      entropy,
+		"board_width":         float64(board.Width),
+		"board_height":        float64(board.Height),
+		"occupied_cell_count": float64(occupiedCellCount(board)),
+	}
+}
+
+func wordLengthStats(placements []WordPlacement) (minLength, maxLength int, average float64) {
+	if len(placements) == 0 {
+		return 0, 0, 0
+	}
+
+	minLength = len(placements[0].Text)
+	total := 0
+	for _, placement := range placements {
+		length := len(placement.Text)
+		minLength = min(minLength, length)
+		maxLength = max(maxLength, length)
+		total += length
+	}
+	return minLength, maxLength, float64(total) / float64(len(placements))
+}
+
+func bankLetterStats(bank string) (repeatedLetters int, entropy float64) {
+	counts := make(map[rune]int)
+	for _, letter := range bank {
+		counts[letter]++
+	}
+	for _, count := range counts {
+		if count > 1 {
+			repeatedLetters += count - 1
+		}
+		probability := float64(count) / float64(len([]rune(bank)))
+		entropy -= probability * math.Log2(probability)
+	}
+	return repeatedLetters, entropy
+}
+
+func crossingCount(placements []WordPlacement) int {
+	counts := make(map[Position]int)
+	for _, placement := range placements {
+		for _, pos := range placement.Positions() {
+			counts[pos]++
+		}
+	}
+
+	crossings := 0
+	for _, count := range counts {
+		if count > 1 {
+			crossings++
+		}
+	}
+	return crossings
+}
+
+func occupiedCellCount(board board) int {
+	count := 0
+	for y := range board.Cells {
+		for x := range board.Cells[y] {
+			if board.Cells[y][x].Occupied {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func normalizedMetric(value, low, high float64) float64 {
+	if value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/spellpuzzle/gamemode.go
+++ b/games/spellpuzzle/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -23,6 +24,7 @@ var (
 	_ game.Mode          = SpellPuzzleMode{}
 	_ game.Spawner       = SpellPuzzleMode{}
 	_ game.SeededSpawner = SpellPuzzleMode{}
+	_ game.EloSpawner    = SpellPuzzleMode{}
 )
 
 func NewMode(title, description string, bankSize, boardWords, minBonusWords int) SpellPuzzleMode {
@@ -57,7 +59,20 @@ var Modes = []game.Mode{
 	NewMode("Hard", "9 letters, 9 board words, largest launch board.", 9, 9, 8),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = spellPuzzleModeDefinitions(Modes)
+
+func spellPuzzleModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{0, 600, 1500, 2400}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Spell Puzzle",

--- a/games/spellpuzzle/spellpuzzle_test.go
+++ b/games/spellpuzzle/spellpuzzle_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 )
 
 func newTestRNG(seed uint64) *rand.Rand {
@@ -63,6 +64,80 @@ func TestGeneratePuzzleSeededDeterministic(t *testing.T) {
 	for i := range puzzleA.Placements {
 		if puzzleA.Placements[i] != puzzleB.Placements[i] {
 			t.Fatalf("placement[%d] mismatch: %+v vs %+v", i, puzzleA.Placements[i], puzzleB.Placements[i])
+		}
+	}
+}
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Easy", "", 7, 6, 4)
+
+	if _, _, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1); err == nil {
+		t.Fatal("SpawnElo returned nil error for invalid Elo")
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Easy", "", 7, 6, 4)
+
+	gameA, reportA, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if reportA.ActualElo != reportB.ActualElo {
+		t.Fatalf("ActualElo mismatch: %d vs %d", reportA.ActualElo, reportB.ActualElo)
+	}
+}
+
+func TestSpawnEloReportPopulated(t *testing.T) {
+	mode := NewMode("Easy", "", 7, 6, 4)
+	_, report, err := mode.SpawnElo("report-seed", 1800)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.TargetElo != 1800 {
+		t.Fatalf("TargetElo = %d, want 1800", report.TargetElo)
+	}
+	if report.ActualElo == 0 {
+		t.Fatal("ActualElo is zero")
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+	if len(report.Metrics) == 0 {
+		t.Fatal("Metrics is empty")
+	}
+
+	for _, key := range []string{
+		"bank_size",
+		"board_word_count",
+		"bonus_word_count",
+		"allowed_word_count",
+		"average_word_length",
+		"crossing_count",
+		"board_width",
+		"board_height",
+		"occupied_cell_count",
+	} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("report metric %q missing from %+v", key, report.Metrics)
 		}
 	}
 }

--- a/games/sudoku/README.md
+++ b/games/sudoku/README.md
@@ -34,6 +34,11 @@ in red.
 | Expert | 22 | X-Wing / Y-Wing |
 | Diabolical | 17 | Swordfish / XY-Chains |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/sudoku/elo.go
+++ b/games/sudoku/elo.go
@@ -25,12 +25,23 @@ func (s SudokuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 	}
 
 	mode := sudokuModeForElo(s, elo)
-	provided := GenerateProvidedCellsSeeded(mode, sudokuEloRNG(seed, elo))
-	g, err := New(mode, provided)
+	var bestProvided []cell
+	var bestReport difficulty.Report
+	haveBest := false
+	for candidate := range difficulty.CandidateCount(elo) {
+		provided := GenerateProvidedCellsSeeded(mode, sudokuEloRNG(sudokuCandidateSeed(seed, candidate), elo))
+		report := scoreSudokuElo(elo, provided)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestProvided = provided
+			bestReport = report
+			haveBest = true
+		}
+	}
+	g, err := New(mode, bestProvided)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return g, scoreSudokuElo(elo, provided), nil
+	return g, bestReport, nil
 }
 
 func sudokuModeForElo(base SudokuMode, elo difficulty.Elo) SudokuMode {
@@ -50,6 +61,13 @@ func sudokuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func sudokuCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func scoreSudokuElo(target difficulty.Elo, provided []cell) difficulty.Report {

--- a/games/sudoku/elo.go
+++ b/games/sudoku/elo.go
@@ -1,0 +1,149 @@
+package sudoku
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = SudokuMode{}
+
+type eloSolveStats struct {
+	Nodes    int
+	Branches int
+	MaxDepth int
+}
+
+func (s SudokuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := sudokuModeForElo(elo)
+	provided := GenerateProvidedCellsSeeded(mode, sudokuEloRNG(seed, elo))
+	g, err := New(mode, provided)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return g, scoreSudokuElo(elo, provided), nil
+}
+
+func sudokuModeForElo(elo difficulty.Elo) SudokuMode {
+	score := difficulty.Score01(elo)
+	provided := 45 - int(math.Round(score*28))
+	if provided < 17 {
+		provided = 17
+	}
+	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted sudoku.", provided)
+}
+
+func sudokuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("sudoku\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreSudokuElo(target difficulty.Elo, provided []cell) difficulty.Report {
+	g := newGrid(provided)
+	solutions, stats := countSolutionsWithEloStats(&g, 2)
+	metrics := difficulty.Metrics{
+		"clue_count":     float64(len(provided)),
+		"unknown_count":  float64(gridSize*gridSize - len(provided)),
+		"solution_count": float64(solutions),
+		"solver_nodes":   float64(stats.Nodes),
+		"branches":       float64(stats.Branches),
+		"max_depth":      float64(stats.MaxDepth),
+	}
+
+	actual := sudokuActualElo(metrics)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  actual,
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func countSolutionsWithEloStats(g *grid, limit int) (int, eloSolveStats) {
+	if limit <= 0 {
+		return 0, eloSolveStats{}
+	}
+
+	masks, ok := buildMasks(g)
+	if !ok {
+		return 0, eloSolveStats{}
+	}
+
+	var stats eloSolveStats
+	count := countSolutionsRecWithEloStats(g, limit, &masks, 0, &stats)
+	return count, stats
+}
+
+func countSolutionsRecWithEloStats(g *grid, limit int, masks *solverMasks, depth int, stats *eloSolveStats) int {
+	if limit <= 0 {
+		return 0
+	}
+
+	stats.Nodes++
+	if depth > stats.MaxDepth {
+		stats.MaxDepth = depth
+	}
+
+	x, y, candidateMask, found := findMostConstrainedEmptyCell(g, masks)
+	if !found {
+		return 1
+	}
+	if candidateMask == 0 {
+		return 0
+	}
+
+	count := 0
+	candidateCount := countCandidateBits(candidateMask)
+	if candidateCount > 1 {
+		stats.Branches++
+	}
+	for val := 1; val <= gridSize; val++ {
+		bit := valueBit(val)
+		if candidateMask&bit == 0 {
+			continue
+		}
+
+		placeValue(g, masks, val, x, y)
+		count += countSolutionsRecWithEloStats(g, limit-count, masks, depth+1, stats)
+		clearValue(g, masks, val, x, y)
+		if count >= limit {
+			return count
+		}
+	}
+	return count
+}
+
+func sudokuActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.55*normalizeSudokuMetric(metrics["unknown_count"], 36, 64) +
+		0.25*normalizeSudokuMetric(math.Log10(metrics["solver_nodes"]+1), 1.2, 4.0) +
+		0.15*normalizeSudokuMetric(metrics["branches"], 0, 120) +
+		0.05*normalizeSudokuMetric(metrics["max_depth"], 0, 64)
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeSudokuMetric(value, low, high float64) float64 {
+	if value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/sudoku/elo.go
+++ b/games/sudoku/elo.go
@@ -24,7 +24,7 @@ func (s SudokuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := sudokuModeForElo(elo)
+	mode := sudokuModeForElo(s, elo)
 	provided := GenerateProvidedCellsSeeded(mode, sudokuEloRNG(seed, elo))
 	g, err := New(mode, provided)
 	if err != nil {
@@ -33,13 +33,15 @@ func (s SudokuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 	return g, scoreSudokuElo(elo, provided), nil
 }
 
-func sudokuModeForElo(elo difficulty.Elo) SudokuMode {
+func sudokuModeForElo(base SudokuMode, elo difficulty.Elo) SudokuMode {
 	score := difficulty.Score01(elo)
 	provided := 45 - int(math.Round(score*28))
 	if provided < 17 {
 		provided = 17
 	}
-	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted sudoku.", provided)
+	mode := base
+	mode.ProvidedCount = provided
+	return mode
 }
 
 func sudokuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/sudoku/elo_test.go
+++ b/games/sudoku/elo_test.go
@@ -1,0 +1,71 @@
+package sudoku
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 32)
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 32)
+	gameA, reportA, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloReportPopulated(t *testing.T) {
+	mode := NewMode("Elo", "test", 32)
+	_, report, err := mode.SpawnElo("report-seed", 1800)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.TargetElo != 1800 {
+		t.Fatalf("TargetElo = %d, want 1800", report.TargetElo)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+	for _, key := range []string{"clue_count", "unknown_count", "solution_count", "solver_nodes", "branches", "max_depth"} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from %+v", key, report.Metrics)
+		}
+	}
+}

--- a/games/sudoku/gamemode.go
+++ b/games/sudoku/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -21,6 +22,7 @@ var (
 	_ game.Mode          = SudokuMode{}
 	_ game.Spawner       = SudokuMode{}
 	_ game.SeededSpawner = SudokuMode{}
+	_ game.EloSpawner    = SudokuMode{}
 )
 
 func NewMode(title, description string, providedCount int) SudokuMode {
@@ -47,7 +49,20 @@ var Modes = []game.Mode{
 	NewMode("Diabolical", "17–21 clues. Swordfish / XY-Chains.", 17),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = sudokuModeDefinitions(Modes)
+
+func sudokuModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{0, 600, 1200, 1800, 2400, 3000}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Sudoku",

--- a/games/sudokurgb/README.md
+++ b/games/sudokurgb/README.md
@@ -42,6 +42,11 @@ three copies of a value.
 | Expert | 36 | Sparse givens require deeper scanning |
 | Diabolical | 30 | Tightest clue budget in the launch set |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/sudokurgb/elo.go
+++ b/games/sudokurgb/elo.go
@@ -1,0 +1,147 @@
+package sudokurgb
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = SudokuRGBMode{}
+
+type eloSolveStats struct {
+	Nodes    int
+	Branches int
+	MaxDepth int
+}
+
+func (s SudokuRGBMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := sudokuRGBModeForElo(elo)
+	provided := GenerateProvidedCellsSeeded(mode, sudokuRGBEloRNG(seed, elo))
+	g, err := New(mode, provided)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return g, scoreSudokuRGBElo(elo, provided), nil
+}
+
+func sudokuRGBModeForElo(elo difficulty.Elo) SudokuRGBMode {
+	score := difficulty.Score01(elo)
+	provided := 60 - int(math.Round(score*30))
+	if provided < 30 {
+		provided = 30
+	}
+	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted sudoku RGB.", provided)
+}
+
+func sudokuRGBEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("sudokurgb\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreSudokuRGBElo(target difficulty.Elo, provided []cell) difficulty.Report {
+	g := newGrid(provided)
+	solutions, stats := countSolutionsWithEloStats(&g, 2)
+	metrics := difficulty.Metrics{
+		"clue_count":     float64(len(provided)),
+		"unknown_count":  float64(gridSize*gridSize - len(provided)),
+		"solution_count": float64(solutions),
+		"solver_nodes":   float64(stats.Nodes),
+		"branches":       float64(stats.Branches),
+		"max_depth":      float64(stats.MaxDepth),
+	}
+
+	actual := sudokuRGBActualElo(metrics)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  actual,
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func countSolutionsWithEloStats(g *grid, limit int) (int, eloSolveStats) {
+	if limit <= 0 {
+		return 0, eloSolveStats{}
+	}
+
+	state, ok := buildQuotaState(g)
+	if !ok {
+		return 0, eloSolveStats{}
+	}
+
+	var stats eloSolveStats
+	count := countSolutionsRecWithEloStats(g, limit, &state, 0, &stats)
+	return count, stats
+}
+
+func countSolutionsRecWithEloStats(g *grid, limit int, state *quotaState, depth int, stats *eloSolveStats) int {
+	if limit <= 0 {
+		return 0
+	}
+
+	stats.Nodes++
+	if depth > stats.MaxDepth {
+		stats.MaxDepth = depth
+	}
+
+	x, y, candidates, found := findMostConstrainedEmptyCell(g, state)
+	if !found {
+		return 1
+	}
+	if candidates == 0 {
+		return 0
+	}
+
+	count := 0
+	candidateCount := countCandidateBits(candidates)
+	if candidateCount > 1 {
+		stats.Branches++
+	}
+	for value := 1; value <= valueCount; value++ {
+		if candidates&(1<<value) == 0 {
+			continue
+		}
+		placeValue(g, state, value, x, y)
+		count += countSolutionsRecWithEloStats(g, limit-count, state, depth+1, stats)
+		clearValue(g, state, value, x, y)
+		if count >= limit {
+			return count
+		}
+	}
+	return count
+}
+
+func sudokuRGBActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.55*normalizeSudokuRGBMetric(metrics["unknown_count"], 21, 51) +
+		0.25*normalizeSudokuRGBMetric(math.Log10(metrics["solver_nodes"]+1), 1.2, 4.0) +
+		0.15*normalizeSudokuRGBMetric(metrics["branches"], 0, 120) +
+		0.05*normalizeSudokuRGBMetric(metrics["max_depth"], 0, 51)
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func normalizeSudokuRGBMetric(value, low, high float64) float64 {
+	if value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}

--- a/games/sudokurgb/elo.go
+++ b/games/sudokurgb/elo.go
@@ -25,19 +25,30 @@ func (s SudokuRGBMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, di
 	}
 
 	mode := sudokuRGBModeForElo(s, elo)
-	provided := GenerateProvidedCellsSeeded(mode, sudokuRGBEloRNG(seed, elo))
-	g, err := New(mode, provided)
+	var bestProvided []cell
+	var bestReport difficulty.Report
+	haveBest := false
+	for candidate := range difficulty.CandidateCount(elo) {
+		provided := GenerateProvidedCellsSeeded(mode, sudokuRGBEloRNG(sudokuRGBCandidateSeed(seed, candidate), elo))
+		report := scoreSudokuRGBElo(elo, provided)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestProvided = provided
+			bestReport = report
+			haveBest = true
+		}
+	}
+	g, err := New(mode, bestProvided)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return g, scoreSudokuRGBElo(elo, provided), nil
+	return g, bestReport, nil
 }
 
 func sudokuRGBModeForElo(base SudokuRGBMode, elo difficulty.Elo) SudokuRGBMode {
 	score := difficulty.Score01(elo)
-	provided := 60 - int(math.Round(score*30))
-	if provided < 30 {
-		provided = 30
+	provided := 60 - int(math.Round(score*36))
+	if provided < 24 {
+		provided = 24
 	}
 	mode := base
 	mode.ProvidedCount = provided
@@ -50,6 +61,13 @@ func sudokuRGBEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 		binary.LittleEndian.Uint64(sum[0:8]),
 		binary.LittleEndian.Uint64(sum[8:16]),
 	))
+}
+
+func sudokuRGBCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + "\x00candidate:" + strconv.Itoa(candidate)
 }
 
 func scoreSudokuRGBElo(target difficulty.Elo, provided []cell) difficulty.Report {
@@ -131,7 +149,7 @@ func countSolutionsRecWithEloStats(g *grid, limit int, state *quotaState, depth 
 }
 
 func sudokuRGBActualElo(metrics difficulty.Metrics) difficulty.Elo {
-	score := 0.55*normalizeSudokuRGBMetric(metrics["unknown_count"], 21, 51) +
+	score := 0.55*normalizeSudokuRGBMetric(metrics["unknown_count"], 21, 57) +
 		0.25*normalizeSudokuRGBMetric(math.Log10(metrics["solver_nodes"]+1), 1.2, 4.0) +
 		0.15*normalizeSudokuRGBMetric(metrics["branches"], 0, 120) +
 		0.05*normalizeSudokuRGBMetric(metrics["max_depth"], 0, 51)

--- a/games/sudokurgb/elo.go
+++ b/games/sudokurgb/elo.go
@@ -24,7 +24,7 @@ func (s SudokuRGBMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, di
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := sudokuRGBModeForElo(elo)
+	mode := sudokuRGBModeForElo(s, elo)
 	provided := GenerateProvidedCellsSeeded(mode, sudokuRGBEloRNG(seed, elo))
 	g, err := New(mode, provided)
 	if err != nil {
@@ -33,13 +33,15 @@ func (s SudokuRGBMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, di
 	return g, scoreSudokuRGBElo(elo, provided), nil
 }
 
-func sudokuRGBModeForElo(elo difficulty.Elo) SudokuRGBMode {
+func sudokuRGBModeForElo(base SudokuRGBMode, elo difficulty.Elo) SudokuRGBMode {
 	score := difficulty.Score01(elo)
 	provided := 60 - int(math.Round(score*30))
 	if provided < 30 {
 		provided = 30
 	}
-	return NewMode("Elo "+strconv.Itoa(int(elo)), "Elo-targeted sudoku RGB.", provided)
+	mode := base
+	mode.ProvidedCount = provided
+	return mode
 }
 
 func sudokuRGBEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/sudokurgb/elo_test.go
+++ b/games/sudokurgb/elo_test.go
@@ -1,0 +1,71 @@
+package sudokurgb
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 48)
+	gamer, report, err := mode.SpawnElo("seed", difficulty.SoftCapElo+1)
+	if err == nil {
+		t.Fatal("SpawnElo returned nil error")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 48)
+	gameA, reportA, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gameB, reportB, err := mode.SpawnElo("same-seed", 1200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	saveA, err := gameA.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saveB, err := gameB.GetSave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloReportPopulated(t *testing.T) {
+	mode := NewMode("Elo", "test", 48)
+	_, report, err := mode.SpawnElo("report-seed", 1800)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.TargetElo != 1800 {
+		t.Fatalf("TargetElo = %d, want 1800", report.TargetElo)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+	for _, key := range []string{"clue_count", "unknown_count", "solution_count", "solver_nodes", "branches", "max_depth"} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("metric %q missing from %+v", key, report.Metrics)
+		}
+	}
+}

--- a/games/sudokurgb/gamemode.go
+++ b/games/sudokurgb/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -21,6 +22,7 @@ var (
 	_ game.Mode          = SudokuRGBMode{}
 	_ game.Spawner       = SudokuRGBMode{}
 	_ game.SeededSpawner = SudokuRGBMode{}
+	_ game.EloSpawner    = SudokuRGBMode{}
 )
 
 func NewMode(title, description string, providedCount int) SudokuRGBMode {
@@ -47,7 +49,20 @@ var Modes = []game.Mode{
 	NewMode("Diabolical", "30 clues. Tightest clue budget in the launch set.", 30),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = sudokuRGBModeDefinitions(Modes)
+
+func sudokuRGBModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{0, 600, 1200, 1800, 2400, 3000}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Sudoku RGB",

--- a/games/takuzu/README.md
+++ b/games/takuzu/README.md
@@ -41,6 +41,11 @@ every cell is filled and all three rules are satisfied.
 | Very Hard | 12x12 | ~30% | Deep logic required |
 | Extreme | 14x14 | ~28% | Maximum challenge |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/takuzu/elo.go
+++ b/games/takuzu/elo.go
@@ -24,7 +24,7 @@ func (t TakuzuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := takuzuModeForElo(elo)
+	mode := takuzuModeForElo(t, elo)
 	rng := takuzuEloRNG(seed, elo)
 	complete := GenerateCompleteGridSeeded(mode.Size, rng)
 	puzzle, provided := GeneratePuzzleFromCompleteSeeded(complete, mode.Size, mode.Prefilled, rng)
@@ -36,16 +36,12 @@ func (t TakuzuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 	return gamer, scoreTakuzuElo(elo, puzzle, provided, mode.Prefilled), nil
 }
 
-func takuzuModeForElo(elo difficulty.Elo) TakuzuMode {
+func takuzuModeForElo(base TakuzuMode, elo difficulty.Elo) TakuzuMode {
 	score := difficulty.Score01(elo)
-	size := 6 + 2*int(math.Round(score*4))
 	prefilled := 0.52 - score*0.24
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Takuzu puzzle.",
-		size,
-		prefilled,
-	)
+	mode := base
+	mode.Prefilled = prefilled
+	return mode
 }
 
 func takuzuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/takuzu/elo.go
+++ b/games/takuzu/elo.go
@@ -1,0 +1,186 @@
+package takuzu
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = TakuzuMode{}
+
+type takuzuEloCounterStats struct {
+	Nodes    int
+	Branches int
+	MaxDepth int
+}
+
+func (t TakuzuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := takuzuModeForElo(elo)
+	rng := takuzuEloRNG(seed, elo)
+	complete := GenerateCompleteGridSeeded(mode.Size, rng)
+	puzzle, provided := GeneratePuzzleFromCompleteSeeded(complete, mode.Size, mode.Prefilled, rng)
+
+	gamer, err := New(mode, puzzle, provided)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, scoreTakuzuElo(elo, puzzle, provided, mode.Prefilled), nil
+}
+
+func takuzuModeForElo(elo difficulty.Elo) TakuzuMode {
+	score := difficulty.Score01(elo)
+	size := 6 + 2*int(math.Round(score*4))
+	prefilled := 0.52 - score*0.24
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Takuzu puzzle.",
+		size,
+		prefilled,
+	)
+}
+
+func takuzuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("takuzu\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreTakuzuElo(target difficulty.Elo, puzzle [][]rune, provided [][]bool, targetPrefilled float64) difficulty.Report {
+	solutions, stats := countTakuzuSolutionsWithEloStats(grid(puzzle).clone(), len(puzzle), 2)
+	metrics := takuzuDifficultyMetrics(puzzle, provided, targetPrefilled, solutions, stats)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  takuzuActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func takuzuDifficultyMetrics(
+	puzzle [][]rune,
+	provided [][]bool,
+	targetPrefilled float64,
+	solutions int,
+	stats takuzuEloCounterStats,
+) difficulty.Metrics {
+	size := len(puzzle)
+	cells := size * size
+	clues := 0
+	for y := range provided {
+		for x := range provided[y] {
+			if provided[y][x] {
+				clues++
+			}
+		}
+	}
+	empties := cells - clues
+
+	return difficulty.Metrics{
+		"size":             float64(size),
+		"cells":            float64(cells),
+		"clue_count":       float64(clues),
+		"empty_count":      float64(empties),
+		"clue_density":     takuzuRatio(clues, cells),
+		"target_prefilled": targetPrefilled,
+		"solution_count":   float64(solutions),
+		"solver_nodes":     float64(stats.Nodes),
+		"branches":         float64(stats.Branches),
+		"max_depth":        float64(stats.MaxDepth),
+	}
+}
+
+func countTakuzuSolutionsWithEloStats(g grid, size, limit int) (int, takuzuEloCounterStats) {
+	if limit <= 0 {
+		return 0, takuzuEloCounterStats{}
+	}
+	stats := newLineStats(g, size)
+	var counter takuzuEloCounterStats
+	count := countTakuzuSolutionsRecWithEloStats(g, size, limit, stats, 0, &counter)
+	return count, counter
+}
+
+func countTakuzuSolutionsRecWithEloStats(
+	g grid,
+	size int,
+	limit int,
+	lineStats *lineStats,
+	depth int,
+	counter *takuzuEloCounterStats,
+) int {
+	counter.Nodes++
+	if depth > counter.MaxDepth {
+		counter.MaxDepth = depth
+	}
+
+	choice := selectMRVCell(g, size, lineStats, nil)
+	if choice.x < 0 {
+		if hasUniqueLines(g, size) {
+			return 1
+		}
+		return 0
+	}
+	if choice.count == 0 {
+		return 0
+	}
+	if choice.count > 1 {
+		counter.Branches++
+	}
+
+	total := 0
+	for i := range choice.count {
+		v := choice.vals[i]
+		g[choice.y][choice.x] = v
+		lineStats.apply(choice.x, choice.y, v, 1)
+		total += countTakuzuSolutionsRecWithEloStats(g, size, limit-total, lineStats, depth+1, counter)
+		lineStats.apply(choice.x, choice.y, v, -1)
+		g[choice.y][choice.x] = emptyCell
+		if total >= limit {
+			return total
+		}
+	}
+
+	return total
+}
+
+func takuzuActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.34*takuzuNormalize(metrics["size"], 6, 14) +
+		0.28*(1-takuzuNormalize(metrics["clue_density"], 0.28, 0.52)) +
+		0.18*takuzuNormalize(metrics["max_depth"], 0, metrics["empty_count"]) +
+		0.12*takuzuNormalize(metrics["branches"], 0, metrics["empty_count"]) +
+		0.08*takuzuNormalize(metrics["solver_nodes"], 1, math.Max(2, metrics["empty_count"]*3))
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func takuzuNormalize(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func takuzuRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/takuzu/elo.go
+++ b/games/takuzu/elo.go
@@ -1,6 +1,7 @@
 package takuzu
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"math"
@@ -11,7 +12,10 @@ import (
 	"github.com/FelineStateMachine/puzzletea/game"
 )
 
-var _ game.EloSpawner = TakuzuMode{}
+var (
+	_ game.EloSpawner            = TakuzuMode{}
+	_ game.CancellableEloSpawner = TakuzuMode{}
+)
 
 type takuzuEloCounterStats struct {
 	Nodes    int
@@ -20,7 +24,14 @@ type takuzuEloCounterStats struct {
 }
 
 func (t TakuzuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return t.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (t TakuzuMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
@@ -33,7 +44,8 @@ func (t TakuzuMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, diffi
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, scoreTakuzuElo(elo, puzzle, provided, mode.Prefilled), nil
+	report := scoreTakuzuElo(ctx, elo, puzzle, provided, mode.Prefilled)
+	return gamer, report, nil
 }
 
 func takuzuModeForElo(base TakuzuMode, elo difficulty.Elo) TakuzuMode {
@@ -52,11 +64,14 @@ func takuzuEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 	))
 }
 
-func scoreTakuzuElo(target difficulty.Elo, puzzle [][]rune, provided [][]bool, targetPrefilled float64) difficulty.Report {
-	solutions, stats := countTakuzuSolutionsWithEloStats(grid(puzzle).clone(), len(puzzle), 2)
+func scoreTakuzuElo(ctx context.Context, target difficulty.Elo, puzzle [][]rune, provided [][]bool, targetPrefilled float64) difficulty.Report {
+	solutions, stats := countTakuzuSolutionsWithEloStats(ctx, grid(puzzle).clone(), len(puzzle), 2)
 	metrics := takuzuDifficultyMetrics(puzzle, provided, targetPrefilled, solutions, stats)
 	confidence := difficulty.ConfidenceHigh
-	if solutions != 1 {
+	if solutions < 0 {
+		confidence = difficulty.ConfidenceLow
+		metrics["solver_limited"] = 1
+	} else if solutions != 1 {
 		confidence = difficulty.ConfidenceLow
 	}
 
@@ -101,17 +116,18 @@ func takuzuDifficultyMetrics(
 	}
 }
 
-func countTakuzuSolutionsWithEloStats(g grid, size, limit int) (int, takuzuEloCounterStats) {
+func countTakuzuSolutionsWithEloStats(ctx context.Context, g grid, size, limit int) (int, takuzuEloCounterStats) {
 	if limit <= 0 {
 		return 0, takuzuEloCounterStats{}
 	}
 	stats := newLineStats(g, size)
 	var counter takuzuEloCounterStats
-	count := countTakuzuSolutionsRecWithEloStats(g, size, limit, stats, 0, &counter)
+	count := countTakuzuSolutionsRecWithEloStats(ctx, g, size, limit, stats, 0, &counter)
 	return count, counter
 }
 
 func countTakuzuSolutionsRecWithEloStats(
+	ctx context.Context,
 	g grid,
 	size int,
 	limit int,
@@ -119,6 +135,9 @@ func countTakuzuSolutionsRecWithEloStats(
 	depth int,
 	counter *takuzuEloCounterStats,
 ) int {
+	if ctx.Err() != nil {
+		return -1
+	}
 	counter.Nodes++
 	if depth > counter.MaxDepth {
 		counter.MaxDepth = depth
@@ -143,9 +162,13 @@ func countTakuzuSolutionsRecWithEloStats(
 		v := choice.vals[i]
 		g[choice.y][choice.x] = v
 		lineStats.apply(choice.x, choice.y, v, 1)
-		total += countTakuzuSolutionsRecWithEloStats(g, size, limit-total, lineStats, depth+1, counter)
+		n := countTakuzuSolutionsRecWithEloStats(ctx, g, size, limit-total, lineStats, depth+1, counter)
 		lineStats.apply(choice.x, choice.y, v, -1)
 		g[choice.y][choice.x] = emptyCell
+		if n < 0 {
+			return n
+		}
+		total += n
 		if total >= limit {
 			return total
 		}

--- a/games/takuzu/elo_test.go
+++ b/games/takuzu/elo_test.go
@@ -1,6 +1,7 @@
 package takuzu
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -28,6 +29,23 @@ func TestSpawnEloRejectsInvalidElo(t *testing.T) {
 				t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
 			}
 		})
+	}
+}
+
+func TestSpawnEloContextCanceled(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gamer, report, err := mode.SpawnEloContext(ctx, "seed", 1200)
+	if err == nil {
+		t.Fatal("SpawnEloContext returned nil error for canceled context")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
 	}
 }
 

--- a/games/takuzu/elo_test.go
+++ b/games/takuzu/elo_test.go
@@ -1,0 +1,107 @@
+package takuzu
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4)
+
+	tests := []difficulty.Elo{
+		difficulty.MinElo - 1,
+		difficulty.SoftCapElo + 1,
+	}
+	for _, elo := range tests {
+		t.Run(fmt.Sprint(elo), func(t *testing.T) {
+			gamer, report, err := mode.SpawnElo("seed", elo)
+			if err == nil {
+				t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+			}
+			if gamer != nil {
+				t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+			}
+			if !reflect.DeepEqual(report, difficulty.Report{}) {
+				t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+			}
+		})
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4)
+	const seed = "takuzu-deterministic"
+	const elo = difficulty.Elo(1700)
+
+	gamerA, reportA, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("report mismatch for same seed/Elo:\n%#v\n\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4)
+	const target = difficulty.Elo(2200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	requiredMetrics := map[string]float64{
+		"size":             1,
+		"cells":            1,
+		"clue_count":       1,
+		"empty_count":      1,
+		"clue_density":     0,
+		"target_prefilled": 0,
+		"solution_count":   1,
+		"solver_nodes":     1,
+		"branches":         0,
+		"max_depth":        0,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %f, want >= %f", key, got, min)
+		}
+	}
+}

--- a/games/takuzu/gamemode.go
+++ b/games/takuzu/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -22,6 +23,7 @@ var (
 	_ game.Mode          = TakuzuMode{}
 	_ game.Spawner       = TakuzuMode{}
 	_ game.SeededSpawner = TakuzuMode{}
+	_ game.EloSpawner    = TakuzuMode{}
 )
 
 func NewMode(title, desc string, size int, prefilled float64) TakuzuMode {
@@ -54,7 +56,23 @@ var Modes = []game.Mode{
 	NewMode("Extreme", "14×14 grid, ~28% clues. Maximum challenge.", 14, 0.28),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = takuzuModeDefinitions(Modes)
+
+func takuzuModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 700, 1100, 1600, 2100, 2500, 2900}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Takuzu",

--- a/games/takuzuplus/README.md
+++ b/games/takuzuplus/README.md
@@ -41,6 +41,11 @@ cell is filled and all four rules are satisfied.
 | Very Hard | 12x12 | ~30% | Sparse givens with tighter clue reading |
 | Extreme | 14x14 | ~28% | Largest board and deepest logic |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/takuzuplus/elo.go
+++ b/games/takuzuplus/elo.go
@@ -1,0 +1,225 @@
+package takuzuplus
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"math/rand/v2"
+	"strconv"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+	"github.com/FelineStateMachine/puzzletea/games/takuzu"
+)
+
+var _ game.EloSpawner = TakuzuPlusMode{}
+
+type takuzuPlusEloCounterStats struct {
+	Nodes    int
+	Branches int
+	MaxDepth int
+}
+
+func (t TakuzuPlusMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	mode := takuzuPlusModeForElo(elo)
+	rng := takuzuPlusEloRNG(seed, elo)
+	complete := generateCompleteSeeded(mode.Size, rng)
+	puzzle, provided, rels := generatePuzzleSeeded(complete, mode.Size, mode.Prefilled, mode.profile, rng)
+
+	gamer, err := New(mode, puzzle, provided, rels)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	return gamer, scoreTakuzuPlusElo(elo, puzzle, provided, rels, mode.Prefilled), nil
+}
+
+func takuzuPlusModeForElo(elo difficulty.Elo) TakuzuPlusMode {
+	score := difficulty.Score01(elo)
+	size := 6 + 2*int(math.Round(score*4))
+	prefilled := 0.52 - score*0.24
+	profileIndex := int(math.Round(score * float64(len(modeProfiles)-1)))
+	if profileIndex < 0 {
+		profileIndex = 0
+	}
+	if profileIndex >= len(modeProfiles) {
+		profileIndex = len(modeProfiles) - 1
+	}
+
+	return NewMode(
+		"Elo "+strconv.Itoa(int(elo)),
+		"Elo-targeted Takuzu+ puzzle.",
+		size,
+		prefilled,
+		modeProfiles[profileIndex],
+	)
+}
+
+func takuzuPlusEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	sum := sha256.Sum256([]byte("takuzuplus\x00" + seed + "\x00" + strconv.Itoa(int(elo))))
+	return rand.New(rand.NewPCG(
+		binary.LittleEndian.Uint64(sum[0:8]),
+		binary.LittleEndian.Uint64(sum[8:16]),
+	))
+}
+
+func scoreTakuzuPlusElo(
+	target difficulty.Elo,
+	puzzle grid,
+	provided [][]bool,
+	rels relations,
+	targetPrefilled float64,
+) difficulty.Report {
+	solutions, stats := countTakuzuPlusSolutionsWithEloStats(puzzle.clone(), len(puzzle), 2, rels)
+	relationMetrics := analyzeRelations(rels, provided, len(puzzle))
+	metrics := takuzuPlusDifficultyMetrics(puzzle, provided, rels, targetPrefilled, solutions, stats, relationMetrics)
+	confidence := difficulty.ConfidenceHigh
+	if solutions != 1 {
+		confidence = difficulty.ConfidenceLow
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  takuzuPlusActualElo(metrics),
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func takuzuPlusDifficultyMetrics(
+	puzzle grid,
+	provided [][]bool,
+	rels relations,
+	targetPrefilled float64,
+	solutions int,
+	stats takuzuPlusEloCounterStats,
+	relationMetrics relationMetrics,
+) difficulty.Metrics {
+	size := len(puzzle)
+	cells := size * size
+	clues := 0
+	for y := range provided {
+		for x := range provided[y] {
+			if provided[y][x] {
+				clues++
+			}
+		}
+	}
+	empties := cells - clues
+	relationCount := countRelations(rels)
+
+	return difficulty.Metrics{
+		"size":               float64(size),
+		"cells":              float64(cells),
+		"clue_count":         float64(clues),
+		"empty_count":        float64(empties),
+		"clue_density":       takuzuPlusRatio(clues, cells),
+		"target_prefilled":   targetPrefilled,
+		"solution_count":     float64(solutions),
+		"solver_nodes":       float64(stats.Nodes),
+		"branches":           float64(stats.Branches),
+		"max_depth":          float64(stats.MaxDepth),
+		"relation_count":     float64(relationCount),
+		"same_relations":     float64(relationMetrics.SameCount),
+		"diff_relations":     float64(relationMetrics.DifferentCount),
+		"horizontal_clues":   float64(relationMetrics.HorizontalCount),
+		"vertical_clues":     float64(relationMetrics.VerticalCount),
+		"occupied_regions":   float64(relationMetrics.OccupiedRegions),
+		"min_relation_gap":   float64(relationMetrics.MinExistingGap),
+		"one_endpoint_clues": float64(relationMetrics.EndpointCounts[endpointOneProvided]),
+	}
+}
+
+func countTakuzuPlusSolutionsWithEloStats(g grid, size, limit int, rels relations) (int, takuzuPlusEloCounterStats) {
+	if limit <= 0 {
+		return 0, takuzuPlusEloCounterStats{}
+	}
+	var counter takuzuPlusEloCounterStats
+	count := countTakuzuPlusSolutionsRecWithEloStats(g, size, limit, rels, 0, &counter)
+	return count, counter
+}
+
+func countTakuzuPlusSolutionsRecWithEloStats(
+	g grid,
+	size int,
+	limit int,
+	rels relations,
+	depth int,
+	counter *takuzuPlusEloCounterStats,
+) int {
+	counter.Nodes++
+	if depth > counter.MaxDepth {
+		counter.MaxDepth = depth
+	}
+
+	choice := selectMRVCell(g, size, rels)
+	if choice.x < 0 {
+		if checkSolvedGrid(g, size, rels) {
+			return 1
+		}
+		return 0
+	}
+	if choice.count == 0 {
+		return 0
+	}
+	if choice.count > 1 {
+		counter.Branches++
+	}
+
+	total := 0
+	for i := range choice.count {
+		val := choice.vals[i]
+		g[choice.y][choice.x] = val
+		total += countTakuzuPlusSolutionsRecWithEloStats(g, size, limit-total, rels, depth+1, counter)
+		g[choice.y][choice.x] = emptyCell
+		if total >= limit {
+			return total
+		}
+	}
+	return total
+}
+
+func checkSolvedGrid(g grid, size int, rels relations) bool {
+	for y := range size {
+		for x := range size {
+			if g[y][x] == emptyCell {
+				return false
+			}
+		}
+	}
+	return takuzu.CheckConstraintsGrid(g, size) &&
+		takuzu.HasUniqueLinesGrid(g, size) &&
+		checkRelations(g, rels)
+}
+
+func takuzuPlusActualElo(metrics difficulty.Metrics) difficulty.Elo {
+	score := 0.30*takuzuPlusNormalize(metrics["size"], 6, 14) +
+		0.24*(1-takuzuPlusNormalize(metrics["clue_density"], 0.28, 0.52)) +
+		0.16*takuzuPlusNormalize(metrics["max_depth"], 0, metrics["empty_count"]) +
+		0.10*takuzuPlusNormalize(metrics["branches"], 0, metrics["empty_count"]) +
+		0.08*takuzuPlusNormalize(metrics["solver_nodes"], 1, math.Max(2, metrics["empty_count"]*3)) +
+		0.08*takuzuPlusNormalize(metrics["relation_count"], 2, 18) +
+		0.04*takuzuPlusNormalize(metrics["occupied_regions"], 1, 4)
+
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func takuzuPlusNormalize(value, low, high float64) float64 {
+	if high <= low || value <= low {
+		return 0
+	}
+	if value >= high {
+		return 1
+	}
+	return (value - low) / (high - low)
+}
+
+func takuzuPlusRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/games/takuzuplus/elo.go
+++ b/games/takuzuplus/elo.go
@@ -25,7 +25,7 @@ func (t TakuzuPlusMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 		return nil, difficulty.Report{}, err
 	}
 
-	mode := takuzuPlusModeForElo(elo)
+	mode := takuzuPlusModeForElo(t, elo)
 	rng := takuzuPlusEloRNG(seed, elo)
 	complete := generateCompleteSeeded(mode.Size, rng)
 	puzzle, provided, rels := generatePuzzleSeeded(complete, mode.Size, mode.Prefilled, mode.profile, rng)
@@ -37,9 +37,8 @@ func (t TakuzuPlusMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 	return gamer, scoreTakuzuPlusElo(elo, puzzle, provided, rels, mode.Prefilled), nil
 }
 
-func takuzuPlusModeForElo(elo difficulty.Elo) TakuzuPlusMode {
+func takuzuPlusModeForElo(base TakuzuPlusMode, elo difficulty.Elo) TakuzuPlusMode {
 	score := difficulty.Score01(elo)
-	size := 6 + 2*int(math.Round(score*4))
 	prefilled := 0.52 - score*0.24
 	profileIndex := int(math.Round(score * float64(len(modeProfiles)-1)))
 	if profileIndex < 0 {
@@ -49,13 +48,10 @@ func takuzuPlusModeForElo(elo difficulty.Elo) TakuzuPlusMode {
 		profileIndex = len(modeProfiles) - 1
 	}
 
-	return NewMode(
-		"Elo "+strconv.Itoa(int(elo)),
-		"Elo-targeted Takuzu+ puzzle.",
-		size,
-		prefilled,
-		modeProfiles[profileIndex],
-	)
+	mode := base
+	mode.Prefilled = prefilled
+	mode.profile = modeProfiles[profileIndex]
+	return mode
 }
 
 func takuzuPlusEloRNG(seed string, elo difficulty.Elo) *rand.Rand {

--- a/games/takuzuplus/elo.go
+++ b/games/takuzuplus/elo.go
@@ -1,6 +1,7 @@
 package takuzuplus
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"math"
@@ -12,7 +13,10 @@ import (
 	"github.com/FelineStateMachine/puzzletea/games/takuzu"
 )
 
-var _ game.EloSpawner = TakuzuPlusMode{}
+var (
+	_ game.EloSpawner            = TakuzuPlusMode{}
+	_ game.CancellableEloSpawner = TakuzuPlusMode{}
+)
 
 type takuzuPlusEloCounterStats struct {
 	Nodes    int
@@ -21,7 +25,14 @@ type takuzuPlusEloCounterStats struct {
 }
 
 func (t TakuzuPlusMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	return t.SpawnEloContext(context.Background(), seed, elo)
+}
+
+func (t TakuzuPlusMode) SpawnEloContext(ctx context.Context, seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
 	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
@@ -34,7 +45,8 @@ func (t TakuzuPlusMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
-	return gamer, scoreTakuzuPlusElo(elo, puzzle, provided, rels, mode.Prefilled), nil
+	report := scoreTakuzuPlusElo(ctx, elo, puzzle, provided, rels, mode.Prefilled)
+	return gamer, report, nil
 }
 
 func takuzuPlusModeForElo(base TakuzuPlusMode, elo difficulty.Elo) TakuzuPlusMode {
@@ -63,17 +75,21 @@ func takuzuPlusEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 }
 
 func scoreTakuzuPlusElo(
+	ctx context.Context,
 	target difficulty.Elo,
 	puzzle grid,
 	provided [][]bool,
 	rels relations,
 	targetPrefilled float64,
 ) difficulty.Report {
-	solutions, stats := countTakuzuPlusSolutionsWithEloStats(puzzle.clone(), len(puzzle), 2, rels)
+	solutions, stats := countTakuzuPlusSolutionsWithEloStats(ctx, puzzle.clone(), len(puzzle), 2, rels)
 	relationMetrics := analyzeRelations(rels, provided, len(puzzle))
 	metrics := takuzuPlusDifficultyMetrics(puzzle, provided, rels, targetPrefilled, solutions, stats, relationMetrics)
 	confidence := difficulty.ConfidenceHigh
-	if solutions != 1 {
+	if solutions < 0 {
+		confidence = difficulty.ConfidenceLow
+		metrics["solver_limited"] = 1
+	} else if solutions != 1 {
 		confidence = difficulty.ConfidenceLow
 	}
 
@@ -129,16 +145,17 @@ func takuzuPlusDifficultyMetrics(
 	}
 }
 
-func countTakuzuPlusSolutionsWithEloStats(g grid, size, limit int, rels relations) (int, takuzuPlusEloCounterStats) {
+func countTakuzuPlusSolutionsWithEloStats(ctx context.Context, g grid, size, limit int, rels relations) (int, takuzuPlusEloCounterStats) {
 	if limit <= 0 {
 		return 0, takuzuPlusEloCounterStats{}
 	}
 	var counter takuzuPlusEloCounterStats
-	count := countTakuzuPlusSolutionsRecWithEloStats(g, size, limit, rels, 0, &counter)
+	count := countTakuzuPlusSolutionsRecWithEloStats(ctx, g, size, limit, rels, 0, &counter)
 	return count, counter
 }
 
 func countTakuzuPlusSolutionsRecWithEloStats(
+	ctx context.Context,
 	g grid,
 	size int,
 	limit int,
@@ -146,6 +163,9 @@ func countTakuzuPlusSolutionsRecWithEloStats(
 	depth int,
 	counter *takuzuPlusEloCounterStats,
 ) int {
+	if ctx.Err() != nil {
+		return -1
+	}
 	counter.Nodes++
 	if depth > counter.MaxDepth {
 		counter.MaxDepth = depth
@@ -169,8 +189,12 @@ func countTakuzuPlusSolutionsRecWithEloStats(
 	for i := range choice.count {
 		val := choice.vals[i]
 		g[choice.y][choice.x] = val
-		total += countTakuzuPlusSolutionsRecWithEloStats(g, size, limit-total, rels, depth+1, counter)
+		n := countTakuzuPlusSolutionsRecWithEloStats(ctx, g, size, limit-total, rels, depth+1, counter)
 		g[choice.y][choice.x] = emptyCell
+		if n < 0 {
+			return n
+		}
+		total += n
 		if total >= limit {
 			return total
 		}

--- a/games/takuzuplus/elo_test.go
+++ b/games/takuzuplus/elo_test.go
@@ -1,6 +1,7 @@
 package takuzuplus
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -25,6 +26,23 @@ func TestSpawnEloRejectsInvalidElo(t *testing.T) {
 		if !reflect.DeepEqual(report, difficulty.Report{}) {
 			t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
 		}
+	}
+}
+
+func TestSpawnEloContextCanceled(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4, modeProfiles[1])
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gamer, report, err := mode.SpawnEloContext(ctx, "seed", 1200)
+	if err == nil {
+		t.Fatal("SpawnEloContext returned nil error for canceled context")
+	}
+	if gamer != nil {
+		t.Fatalf("gamer = %#v, want nil", gamer)
+	}
+	if !reflect.DeepEqual(report, difficulty.Report{}) {
+		t.Fatalf("report = %#v, want zero report", report)
 	}
 }
 

--- a/games/takuzuplus/elo_test.go
+++ b/games/takuzuplus/elo_test.go
@@ -1,0 +1,100 @@
+package takuzuplus
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4, modeProfiles[1])
+	tests := []difficulty.Elo{
+		difficulty.MinElo - 1,
+		difficulty.SoftCapElo + 1,
+	}
+
+	for _, elo := range tests {
+		gamer, report, err := mode.SpawnElo("seed", elo)
+		if err == nil {
+			t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+		}
+		if gamer != nil {
+			t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+		}
+		if !reflect.DeepEqual(report, difficulty.Report{}) {
+			t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+		}
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4, modeProfiles[1])
+	const elo = difficulty.Elo(900)
+	const seed = "same-seed"
+
+	gamerA, reportA, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	saveA, err := gamerA.GetSave()
+	if err != nil {
+		t.Fatalf("first GetSave returned error: %v", err)
+	}
+	saveB, err := gamerB.GetSave()
+	if err != nil {
+		t.Fatalf("second GetSave returned error: %v", err)
+	}
+	if string(saveA) != string(saveB) {
+		t.Fatalf("SpawnElo saves differ for same seed and Elo:\n%s\n%s", saveA, saveB)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("reports differ for same seed and Elo:\n%#v\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 8, 0.4, modeProfiles[1])
+	const target = difficulty.Elo(1200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	for _, key := range []string{
+		"size",
+		"clue_density",
+		"solution_count",
+		"solver_nodes",
+		"max_depth",
+		"relation_count",
+		"same_relations",
+		"diff_relations",
+		"occupied_regions",
+	} {
+		if _, ok := report.Metrics[key]; !ok {
+			t.Fatalf("Metrics missing %q: %#v", key, report.Metrics)
+		}
+	}
+	if report.Metrics["relation_count"] == 0 {
+		t.Fatalf("relation_count = 0, want relation clues in report: %#v", report.Metrics)
+	}
+}

--- a/games/takuzuplus/gamemode.go
+++ b/games/takuzuplus/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -23,6 +24,7 @@ var (
 	_ game.Mode          = TakuzuPlusMode{}
 	_ game.Spawner       = TakuzuPlusMode{}
 	_ game.SeededSpawner = TakuzuPlusMode{}
+	_ game.EloSpawner    = TakuzuPlusMode{}
 )
 
 func NewMode(title, desc string, size int, prefilled float64, profile relationProfile) TakuzuPlusMode {
@@ -58,7 +60,23 @@ var Modes = []game.Mode{
 	NewMode("Extreme", "14×14 grid, maximum size with additive relation clues.", 14, 0.28, modeProfiles[6]),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = takuzuPlusModeDefinitions(Modes)
+
+func takuzuPlusModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{300, 700, 1100, 1600, 2100, 2500, 2900}
+	for i, mode := range modes {
+		if i >= len(defs) || i >= len(presets) {
+			break
+		}
+		if _, ok := mode.(game.EloSpawner); !ok {
+			continue
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Takuzu+",

--- a/games/wordsearch/README.md
+++ b/games/wordsearch/README.md
@@ -34,6 +34,11 @@ The puzzle is solved when all words are found.
 | Medium | 15x15 | 10 | 6 | + DownLeft, Left, Up |
 | Hard | 20x20 | 15 | 8 | All 8 directions |
 
+## Elo Difficulty
+
+Named modes are compatibility presets. Use `--difficulty <0..3000>` to target a
+specific Elo difficulty for generated puzzles.
+
 ## Quick Start
 
 ```bash

--- a/games/wordsearch/elo.go
+++ b/games/wordsearch/elo.go
@@ -1,0 +1,206 @@
+package wordsearch
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand/v2"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+	"github.com/FelineStateMachine/puzzletea/game"
+)
+
+var _ game.EloSpawner = WordSearchMode{}
+
+type wordSearchEloSpec struct {
+	width       int
+	height      int
+	wordCount   int
+	minWordLen  int
+	maxWordLen  int
+	allowedDirs []Direction
+}
+
+func (w WordSearchMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, difficulty.Report, error) {
+	if err := difficulty.ValidateElo(elo); err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	spec := wordSearchSpecForElo(elo)
+	rng := wordSearchEloRNG(seed, elo)
+	g, words, stats := generateWordSearchSeededWithStats(
+		spec.width,
+		spec.height,
+		spec.wordCount,
+		spec.minWordLen,
+		spec.maxWordLen,
+		spec.allowedDirs,
+		rng,
+	)
+
+	mode := w
+	mode.Width = spec.width
+	mode.Height = spec.height
+	mode.WordCount = spec.wordCount
+	mode.MinWordLen = spec.minWordLen
+	mode.MaxWordLen = spec.maxWordLen
+	mode.AllowedDirs = append([]Direction(nil), spec.allowedDirs...)
+
+	gamer, err := New(mode, g, words)
+	if err != nil {
+		return nil, difficulty.Report{}, err
+	}
+
+	report := wordSearchDifficultyReport(elo, spec, words, stats)
+	return gamer, report, nil
+}
+
+func wordSearchSpecForElo(elo difficulty.Elo) wordSearchEloSpec {
+	score := difficulty.Score01(elo)
+	dirCount := 3 + int(math.Round(score*5))
+	if dirCount > len(selectionDirections) {
+		dirCount = len(selectionDirections)
+	}
+
+	minLen := 3 + int(math.Floor(score*3))
+	maxLen := 5 + int(math.Round(score*5))
+	if maxLen < minLen {
+		maxLen = minLen
+	}
+
+	return wordSearchEloSpec{
+		width:       10 + int(math.Round(score*10)),
+		height:      10 + int(math.Round(score*10)),
+		wordCount:   6 + int(math.Round(score*9)),
+		minWordLen:  minLen,
+		maxWordLen:  maxLen,
+		allowedDirs: append([]Direction(nil), selectionDirections[:dirCount]...),
+	}
+}
+
+func wordSearchEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("wordsearch"))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(seed))
+	_, _ = h.Write([]byte(fmt.Sprintf("\x00%d", elo)))
+	s := h.Sum64()
+	return rand.New(rand.NewPCG(s, ^s))
+}
+
+func wordSearchDifficultyReport(
+	target difficulty.Elo,
+	spec wordSearchEloSpec,
+	words []Word,
+	stats placementStats,
+) difficulty.Report {
+	metrics := wordSearchDifficultyMetrics(spec, words, stats)
+	actual := wordSearchActualElo(metrics, stats)
+
+	confidence := difficulty.ConfidenceHigh
+	if stats.PlacedWords != stats.TargetWords {
+		confidence = difficulty.ConfidenceMedium
+	}
+
+	return difficulty.Report{
+		TargetElo:  target,
+		ActualElo:  actual,
+		Confidence: confidence,
+		Metrics:    metrics,
+	}
+}
+
+func wordSearchDifficultyMetrics(spec wordSearchEloSpec, words []Word, stats placementStats) difficulty.Metrics {
+	occupied := occupiedWordCells(words)
+	totalCells := spec.width * spec.height
+	avgWordLen, maxWordLen := wordLengthMetrics(words)
+	uniqueDirs := uniqueDirectionCount(words)
+	fallbackRate := 0.0
+	if stats.TargetWords > 0 {
+		fallbackRate = float64(stats.FallbackUsed) / float64(stats.TargetWords)
+	}
+
+	return difficulty.Metrics{
+		"width":             float64(spec.width),
+		"height":            float64(spec.height),
+		"cells":             float64(totalCells),
+		"target_words":      float64(stats.TargetWords),
+		"placed_words":      float64(stats.PlacedWords),
+		"failed_words":      float64(stats.FailedWords),
+		"success_rate":      stats.SuccessRate(),
+		"avg_word_length":   avgWordLen,
+		"max_word_length":   float64(maxWordLen),
+		"unique_directions": float64(uniqueDirs),
+		"occupied_cells":    float64(occupied),
+		"density":           safeRatio(occupied, totalCells),
+		"attempts_per_word": stats.AttemptsPerWord(),
+		"fallback_rate":     fallbackRate,
+	}
+}
+
+func wordSearchActualElo(metrics difficulty.Metrics, stats placementStats) difficulty.Elo {
+	score := 0.20*normalize(metrics["cells"], 100, 400) +
+		0.20*normalize(metrics["placed_words"], 6, 15) +
+		0.20*normalize(metrics["avg_word_length"], 3, 10) +
+		0.15*normalize(metrics["unique_directions"], 3, 8) +
+		0.15*normalize(metrics["density"], 0.10, 0.45) +
+		0.10*normalize(metrics["attempts_per_word"], 1, 20)
+
+	score *= stats.SuccessRate()
+	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))
+}
+
+func occupiedWordCells(words []Word) int {
+	seen := make(map[Position]struct{})
+	for i := range words {
+		for _, pos := range words[i].Positions() {
+			seen[pos] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func wordLengthMetrics(words []Word) (float64, int) {
+	if len(words) == 0 {
+		return 0, 0
+	}
+
+	total := 0
+	maxLen := 0
+	for _, word := range words {
+		length := len(word.Text)
+		total += length
+		if length > maxLen {
+			maxLen = length
+		}
+	}
+	return float64(total) / float64(len(words)), maxLen
+}
+
+func uniqueDirectionCount(words []Word) int {
+	seen := make(map[Direction]struct{})
+	for _, word := range words {
+		seen[word.Direction] = struct{}{}
+	}
+	return len(seen)
+}
+
+func safeRatio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+func normalize(value, min, max float64) float64 {
+	if max <= min {
+		return 0
+	}
+	if value <= min {
+		return 0
+	}
+	if value >= max {
+		return 1
+	}
+	return (value - min) / (max - min)
+}

--- a/games/wordsearch/elo.go
+++ b/games/wordsearch/elo.go
@@ -26,7 +26,7 @@ func (w WordSearchMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 		return nil, difficulty.Report{}, err
 	}
 
-	spec := wordSearchSpecForElo(elo)
+	spec := wordSearchSpecForElo(w, elo)
 	rng := wordSearchEloRNG(seed, elo)
 	g, words, stats := generateWordSearchSeededWithStats(
 		spec.width,
@@ -55,7 +55,7 @@ func (w WordSearchMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 	return gamer, report, nil
 }
 
-func wordSearchSpecForElo(elo difficulty.Elo) wordSearchEloSpec {
+func wordSearchSpecForElo(base WordSearchMode, elo difficulty.Elo) wordSearchEloSpec {
 	score := difficulty.Score01(elo)
 	dirCount := 3 + int(math.Round(score*5))
 	if dirCount > len(selectionDirections) {
@@ -64,14 +64,19 @@ func wordSearchSpecForElo(elo difficulty.Elo) wordSearchEloSpec {
 
 	minLen := 3 + int(math.Floor(score*3))
 	maxLen := 5 + int(math.Round(score*5))
+	maxAllowedLen := max(base.Width, base.Height)
+	minLen = min(minLen, maxAllowedLen)
+	maxLen = min(maxLen, maxAllowedLen)
 	if maxLen < minLen {
 		maxLen = minLen
 	}
+	wordCount := 6 + int(math.Round(score*9))
+	wordCount = min(wordCount, max(1, base.Width*base.Height/minLen))
 
 	return wordSearchEloSpec{
-		width:       10 + int(math.Round(score*10)),
-		height:      10 + int(math.Round(score*10)),
-		wordCount:   6 + int(math.Round(score*9)),
+		width:       base.Width,
+		height:      base.Height,
+		wordCount:   wordCount,
 		minWordLen:  minLen,
 		maxWordLen:  maxLen,
 		allowedDirs: append([]Direction(nil), selectionDirections[:dirCount]...),

--- a/games/wordsearch/elo.go
+++ b/games/wordsearch/elo.go
@@ -27,16 +27,29 @@ func (w WordSearchMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 	}
 
 	spec := wordSearchSpecForElo(w, elo)
-	rng := wordSearchEloRNG(seed, elo)
-	g, words, stats := generateWordSearchSeededWithStats(
-		spec.width,
-		spec.height,
-		spec.wordCount,
-		spec.minWordLen,
-		spec.maxWordLen,
-		spec.allowedDirs,
-		rng,
-	)
+	var bestGrid grid
+	var bestWords []Word
+	var bestReport difficulty.Report
+	haveBest := false
+	for candidate := range difficulty.CandidateCount(elo) {
+		rng := wordSearchEloRNG(wordSearchCandidateSeed(seed, candidate), elo)
+		g, words, stats := generateWordSearchSeededWithStats(
+			spec.width,
+			spec.height,
+			spec.wordCount,
+			spec.minWordLen,
+			spec.maxWordLen,
+			spec.allowedDirs,
+			rng,
+		)
+		report := wordSearchDifficultyReport(elo, spec, words, stats)
+		if difficulty.BetterCandidate(report, bestReport, elo, haveBest) {
+			bestGrid = g
+			bestWords = words
+			bestReport = report
+			haveBest = true
+		}
+	}
 
 	mode := w
 	mode.Width = spec.width
@@ -46,13 +59,12 @@ func (w WordSearchMode) SpawnElo(seed string, elo difficulty.Elo) (game.Gamer, d
 	mode.MaxWordLen = spec.maxWordLen
 	mode.AllowedDirs = append([]Direction(nil), spec.allowedDirs...)
 
-	gamer, err := New(mode, g, words)
+	gamer, err := New(mode, bestGrid, bestWords)
 	if err != nil {
 		return nil, difficulty.Report{}, err
 	}
 
-	report := wordSearchDifficultyReport(elo, spec, words, stats)
-	return gamer, report, nil
+	return gamer, bestReport, nil
 }
 
 func wordSearchSpecForElo(base WordSearchMode, elo difficulty.Elo) wordSearchEloSpec {
@@ -70,7 +82,7 @@ func wordSearchSpecForElo(base WordSearchMode, elo difficulty.Elo) wordSearchElo
 	if maxLen < minLen {
 		maxLen = minLen
 	}
-	wordCount := 6 + int(math.Round(score*9))
+	wordCount := 5 + int(math.Round(score*13))
 	wordCount = min(wordCount, max(1, base.Width*base.Height/minLen))
 
 	return wordSearchEloSpec{
@@ -91,6 +103,13 @@ func wordSearchEloRNG(seed string, elo difficulty.Elo) *rand.Rand {
 	_, _ = h.Write([]byte(fmt.Sprintf("\x00%d", elo)))
 	s := h.Sum64()
 	return rand.New(rand.NewPCG(s, ^s))
+}
+
+func wordSearchCandidateSeed(seed string, candidate int) string {
+	if candidate == 0 {
+		return seed
+	}
+	return seed + fmt.Sprintf("\x00candidate:%d", candidate)
 }
 
 func wordSearchDifficultyReport(
@@ -144,12 +163,12 @@ func wordSearchDifficultyMetrics(spec wordSearchEloSpec, words []Word, stats pla
 }
 
 func wordSearchActualElo(metrics difficulty.Metrics, stats placementStats) difficulty.Elo {
-	score := 0.20*normalize(metrics["cells"], 100, 400) +
-		0.20*normalize(metrics["placed_words"], 6, 15) +
-		0.20*normalize(metrics["avg_word_length"], 3, 10) +
+	score := 0.16*normalize(metrics["cells"], 100, 400) +
+		0.24*normalize(metrics["placed_words"], 5, 18) +
+		0.22*normalize(metrics["avg_word_length"], 3, 10) +
 		0.15*normalize(metrics["unique_directions"], 3, 8) +
-		0.15*normalize(metrics["density"], 0.10, 0.45) +
-		0.10*normalize(metrics["attempts_per_word"], 1, 20)
+		0.16*normalize(metrics["density"], 0.08, 0.36) +
+		0.07*normalize(metrics["attempts_per_word"], 1, 20)
 
 	score *= stats.SuccessRate()
 	return difficulty.ClampElo(difficulty.Elo(math.Round(score * float64(difficulty.SoftCapElo))))

--- a/games/wordsearch/elo_test.go
+++ b/games/wordsearch/elo_test.go
@@ -1,0 +1,107 @@
+package wordsearch
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
+
+func TestSpawnEloRejectsInvalidElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 10, 10, 6, 3, 5, []Direction{Right, Down, DownRight})
+
+	tests := []difficulty.Elo{
+		difficulty.MinElo - 1,
+		difficulty.SoftCapElo + 1,
+	}
+	for _, elo := range tests {
+		t.Run(fmt.Sprint(elo), func(t *testing.T) {
+			gamer, report, err := mode.SpawnElo("seed", elo)
+			if err == nil {
+				t.Fatalf("SpawnElo(%d) error = nil, want invalid Elo error", elo)
+			}
+			if gamer != nil {
+				t.Fatalf("SpawnElo(%d) gamer = %#v, want nil", elo, gamer)
+			}
+			if !reflect.DeepEqual(report, difficulty.Report{}) {
+				t.Fatalf("SpawnElo(%d) report = %#v, want zero report", elo, report)
+			}
+		})
+	}
+}
+
+func TestSpawnEloDeterministicForSameSeedAndElo(t *testing.T) {
+	mode := NewMode("Elo", "test", 10, 10, 6, 3, 5, []Direction{Right, Down, DownRight})
+	const seed = "wordsearch-deterministic"
+	const elo = difficulty.Elo(1735)
+
+	gamerA, reportA, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("first SpawnElo returned error: %v", err)
+	}
+	gamerB, reportB, err := mode.SpawnElo(seed, elo)
+	if err != nil {
+		t.Fatalf("second SpawnElo returned error: %v", err)
+	}
+
+	modelA := gamerA.(*Model)
+	modelB := gamerB.(*Model)
+
+	if got, want := modelA.grid.String(), modelB.grid.String(); got != want {
+		t.Fatalf("grid mismatch for same seed/Elo:\n%s\n\n%s", got, want)
+	}
+	if !reflect.DeepEqual(modelA.words, modelB.words) {
+		t.Fatalf("words mismatch for same seed/Elo:\n%#v\n\n%#v", modelA.words, modelB.words)
+	}
+	if !reflect.DeepEqual(reportA, reportB) {
+		t.Fatalf("report mismatch for same seed/Elo:\n%#v\n\n%#v", reportA, reportB)
+	}
+}
+
+func TestSpawnEloPopulatesDifficultyReport(t *testing.T) {
+	mode := NewMode("Elo", "test", 10, 10, 6, 3, 5, []Direction{Right, Down, DownRight})
+	const target = difficulty.Elo(2200)
+
+	gamer, report, err := mode.SpawnElo("report-fields", target)
+	if err != nil {
+		t.Fatalf("SpawnElo returned error: %v", err)
+	}
+	if gamer == nil {
+		t.Fatal("SpawnElo returned nil gamer")
+	}
+	if report.TargetElo != target {
+		t.Fatalf("TargetElo = %d, want %d", report.TargetElo, target)
+	}
+	if err := difficulty.ValidateElo(report.ActualElo); err != nil {
+		t.Fatalf("ActualElo = %d is invalid: %v", report.ActualElo, err)
+	}
+	if report.Confidence == "" {
+		t.Fatal("Confidence is empty")
+	}
+
+	requiredMetrics := map[string]float64{
+		"width":             1,
+		"height":            1,
+		"cells":             1,
+		"target_words":      1,
+		"placed_words":      1,
+		"success_rate":      0,
+		"avg_word_length":   1,
+		"max_word_length":   1,
+		"unique_directions": 1,
+		"occupied_cells":    1,
+		"density":           0,
+		"attempts_per_word": 1,
+		"fallback_rate":     0,
+	}
+	for key, min := range requiredMetrics {
+		got, ok := report.Metrics[key]
+		if !ok {
+			t.Fatalf("Metrics[%q] missing from %#v", key, report.Metrics)
+		}
+		if got < min {
+			t.Fatalf("Metrics[%q] = %v, want >= %v", key, got, min)
+		}
+	}
+}

--- a/games/wordsearch/gamemode.go
+++ b/games/wordsearch/gamemode.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"math/rand/v2"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/gameentry"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -26,6 +27,7 @@ var (
 	_ game.Mode          = WordSearchMode{}
 	_ game.Spawner       = WordSearchMode{}
 	_ game.SeededSpawner = WordSearchMode{}
+	_ game.EloSpawner    = WordSearchMode{}
 )
 
 func NewMode(title, description string, width, height, wordCount, minLen, maxLen int, allowedDirs []Direction) WordSearchMode {
@@ -56,7 +58,20 @@ var Modes = []game.Mode{
 	NewMode("Hard 20x20", "Find 15 words in a 20x20 grid.", 20, 20, 15, 5, 10, []Direction{Right, Down, DownRight, DownLeft, Left, Up, UpRight, UpLeft}),
 }
 
-var ModeDefinitions = gameentry.BuildModeDefs(Modes)
+var ModeDefinitions = wordSearchModeDefinitions(Modes)
+
+func wordSearchModeDefinitions(modes []game.Mode) []puzzle.ModeDef {
+	defs := gameentry.BuildModeDefs(modes)
+	presets := []difficulty.Elo{600, 1500, 2400}
+	for i := range defs {
+		if i >= len(presets) {
+			break
+		}
+		elo := presets[i]
+		defs[i].PresetElo = &elo
+	}
+	return defs
+}
 
 var Definition = puzzle.NewDefinition(puzzle.DefinitionSpec{
 	Name:         "Word Search",

--- a/puzzle/puzzle.go
+++ b/puzzle/puzzle.go
@@ -40,6 +40,7 @@ type LegacyModeAlias struct {
 	Description     string
 	TargetVariantID VariantID
 	PresetElo       difficulty.Elo
+	XPWeight        int
 	CLIAliases      []string
 }
 
@@ -49,6 +50,7 @@ type LegacyModeAliasSpec struct {
 	Description     string
 	TargetVariantID VariantID
 	PresetElo       difficulty.Elo
+	XPWeight        int
 	CLIAliases      []string
 }
 
@@ -114,12 +116,17 @@ func NewLegacyModeAlias(spec LegacyModeAliasSpec) LegacyModeAlias {
 	if id == "" {
 		id = CanonicalModeID(spec.Title)
 	}
+	xpWeight := spec.XPWeight
+	if xpWeight < 1 {
+		xpWeight = 1
+	}
 	return LegacyModeAlias{
 		ID:              id,
 		Title:           spec.Title,
 		Description:     spec.Description,
 		TargetVariantID: spec.TargetVariantID,
 		PresetElo:       spec.PresetElo,
+		XPWeight:        xpWeight,
 		CLIAliases:      append([]string(nil), spec.CLIAliases...),
 	}
 }

--- a/puzzle/puzzle.go
+++ b/puzzle/puzzle.go
@@ -1,6 +1,10 @@
 package puzzle
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/FelineStateMachine/puzzletea/difficulty"
+)
 
 type GameID string
 
@@ -11,6 +15,7 @@ type ModeDef struct {
 	Title       string
 	Description string
 	Seeded      bool
+	PresetElo   *difficulty.Elo
 }
 
 type ModeSpec struct {
@@ -18,6 +23,7 @@ type ModeSpec struct {
 	Title       string
 	Description string
 	Seeded      bool
+	PresetElo   *difficulty.Elo
 }
 
 type Definition struct {
@@ -48,6 +54,7 @@ func NewModeDef(spec ModeSpec) ModeDef {
 		Title:       spec.Title,
 		Description: spec.Description,
 		Seeded:      spec.Seeded,
+		PresetElo:   cloneElo(spec.PresetElo),
 	}
 }
 
@@ -64,6 +71,14 @@ func NewDefinition(spec DefinitionSpec) Definition {
 		Modes:        append([]ModeDef(nil), spec.Modes...),
 		DailyModeIDs: append([]ModeID(nil), spec.DailyModeIDs...),
 	}
+}
+
+func cloneElo(elo *difficulty.Elo) *difficulty.Elo {
+	if elo == nil {
+		return nil
+	}
+	v := *elo
+	return &v
 }
 
 func SelectModeIDsByIndex(modes []ModeDef, indexes ...int) []ModeID {

--- a/puzzle/puzzle.go
+++ b/puzzle/puzzle.go
@@ -18,6 +18,40 @@ type ModeDef struct {
 	PresetElo   *difficulty.Elo
 }
 
+type VariantID string
+
+type VariantDef struct {
+	ID          VariantID
+	Title       string
+	Description string
+	DefaultElo  difficulty.Elo
+}
+
+type VariantSpec struct {
+	ID          VariantID
+	Title       string
+	Description string
+	DefaultElo  difficulty.Elo
+}
+
+type LegacyModeAlias struct {
+	ID              ModeID
+	Title           string
+	Description     string
+	TargetVariantID VariantID
+	PresetElo       difficulty.Elo
+	CLIAliases      []string
+}
+
+type LegacyModeAliasSpec struct {
+	ID              ModeID
+	Title           string
+	Description     string
+	TargetVariantID VariantID
+	PresetElo       difficulty.Elo
+	CLIAliases      []string
+}
+
 type ModeSpec struct {
 	ID          ModeID
 	Title       string
@@ -31,6 +65,8 @@ type Definition struct {
 	Name         string
 	Description  string
 	Aliases      []string
+	Variants     []VariantDef
+	LegacyModes  []LegacyModeAlias
 	Modes        []ModeDef
 	DailyModeIDs []ModeID
 }
@@ -40,6 +76,8 @@ type DefinitionSpec struct {
 	Name         string
 	Description  string
 	Aliases      []string
+	Variants     []VariantDef
+	LegacyModes  []LegacyModeAlias
 	Modes        []ModeDef
 	DailyModeIDs []ModeID
 }
@@ -58,6 +96,34 @@ func NewModeDef(spec ModeSpec) ModeDef {
 	}
 }
 
+func NewVariantDef(spec VariantSpec) VariantDef {
+	id := spec.ID
+	if id == "" {
+		id = CanonicalVariantID(spec.Title)
+	}
+	return VariantDef{
+		ID:          id,
+		Title:       spec.Title,
+		Description: spec.Description,
+		DefaultElo:  spec.DefaultElo,
+	}
+}
+
+func NewLegacyModeAlias(spec LegacyModeAliasSpec) LegacyModeAlias {
+	id := spec.ID
+	if id == "" {
+		id = CanonicalModeID(spec.Title)
+	}
+	return LegacyModeAlias{
+		ID:              id,
+		Title:           spec.Title,
+		Description:     spec.Description,
+		TargetVariantID: spec.TargetVariantID,
+		PresetElo:       spec.PresetElo,
+		CLIAliases:      append([]string(nil), spec.CLIAliases...),
+	}
+}
+
 func NewDefinition(spec DefinitionSpec) Definition {
 	id := spec.ID
 	if id == "" {
@@ -68,6 +134,8 @@ func NewDefinition(spec DefinitionSpec) Definition {
 		Name:         spec.Name,
 		Description:  spec.Description,
 		Aliases:      append([]string(nil), spec.Aliases...),
+		Variants:     append([]VariantDef(nil), spec.Variants...),
+		LegacyModes:  append([]LegacyModeAlias(nil), spec.LegacyModes...),
 		Modes:        append([]ModeDef(nil), spec.Modes...),
 		DailyModeIDs: append([]ModeID(nil), spec.DailyModeIDs...),
 	}
@@ -107,9 +175,22 @@ func CanonicalModeID(title string) ModeID {
 	return ModeID(NormalizeName(title))
 }
 
+func CanonicalVariantID(title string) VariantID {
+	return VariantID(NormalizeName(title))
+}
+
 func (d Definition) HasMode(id ModeID) bool {
 	for _, mode := range d.Modes {
 		if mode.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (d Definition) HasVariant(id VariantID) bool {
+	for _, variant := range d.Variants {
+		if variant.ID == id {
 			return true
 		}
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -27,8 +27,9 @@ import (
 )
 
 type (
-	ModeEntry = gameentry.ModeEntry
-	Entry     = gameentry.Entry
+	ModeEntry    = gameentry.ModeEntry
+	VariantEntry = gameentry.VariantEntry
+	Entry        = gameentry.Entry
 )
 
 type DailyEntry struct {
@@ -124,23 +125,25 @@ func Import(gameType string, data []byte) (game.Gamer, error) {
 func DailyEntries() []DailyEntry {
 	dailies := index.DailyEntries()
 	result := make([]DailyEntry, 0, len(dailies))
+	seen := make(map[puzzle.GameID]struct{}, len(dailies))
 	for _, daily := range dailies {
+		if _, ok := seen[daily.GameID]; ok {
+			continue
+		}
 		entry, ok := entriesByID[daily.GameID]
 		if !ok {
 			continue
 		}
-		for _, mode := range entry.Modes {
-			if mode.Definition.ID != daily.ModeID || mode.Seeded == nil {
-				continue
-			}
+		if len(entry.Variants) > 0 && entry.Variants[0].Seeded != nil {
+			variant := entry.Variants[0]
+			seen[daily.GameID] = struct{}{}
 			result = append(result, DailyEntry{
-				Spawner:  mode.Seeded,
+				Spawner:  variant.Seeded,
 				GameID:   daily.GameID,
 				GameType: entry.Definition.Name,
-				ModeID:   daily.ModeID,
-				Mode:     mode.Definition.Title,
+				ModeID:   puzzle.ModeID(variant.Definition.ID),
+				Mode:     variant.Definition.Title,
 			})
-			break
 		}
 	}
 	return result

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -63,6 +63,31 @@ func TestEntriesStayAlignedWithDefinitions(t *testing.T) {
 		if got, want := len(entry.Modes), len(def.Modes); got != want {
 			t.Fatalf("%s mode count = %d, want %d", def.Name, got, want)
 		}
+		if got, want := len(entry.Variants), len(def.Variants); got != want {
+			t.Fatalf("%s variant count = %d, want %d", def.Name, got, want)
+		}
+	}
+}
+
+func TestEntriesExposeVariantsAndValidLegacyAliases(t *testing.T) {
+	for _, entry := range Entries() {
+		if len(entry.Variants) == 0 {
+			t.Fatalf("%s has no variants", entry.Definition.Name)
+		}
+
+		variantIDs := make(map[string]struct{}, len(entry.Variants))
+		for _, variant := range entry.Variants {
+			if variant.Elo == nil {
+				t.Fatalf("%s/%s missing Elo spawner", entry.Definition.Name, variant.Definition.Title)
+			}
+			variantIDs[string(variant.Definition.ID)] = struct{}{}
+		}
+
+		for _, alias := range entry.LegacyModes {
+			if _, ok := variantIDs[string(alias.TargetVariantID)]; !ok {
+				t.Fatalf("%s legacy alias %s targets missing variant %s", entry.Definition.Name, alias.Title, alias.TargetVariantID)
+			}
+		}
 	}
 }
 

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"strings"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
 	"github.com/FelineStateMachine/puzzletea/registry"
@@ -39,11 +40,91 @@ func ModeEntry(entry registry.Entry, name string) (registry.ModeEntry, error) {
 		name, entry.Definition.Name, strings.Join(ModeNames(entry), "\n  "))
 }
 
+type VariantSelection struct {
+	Variant      registry.VariantEntry
+	ExplicitElo  *difficulty.Elo
+	LegacyAlias  *puzzle.LegacyModeAlias
+	DisplayTitle string
+}
+
+func VariantEntry(entry registry.Entry, name string) (VariantSelection, error) {
+	if len(entry.Variants) == 0 {
+		return VariantSelection{}, fmt.Errorf("game %q has no available variants", entry.Definition.Name)
+	}
+
+	if name == "" {
+		variant := entry.Variants[0]
+		return VariantSelection{
+			Variant:      variant,
+			DisplayTitle: variant.Definition.Title,
+		}, nil
+	}
+
+	norm := Normalize(name)
+	for _, variant := range entry.Variants {
+		if Normalize(variant.Definition.Title) == norm || Normalize(string(variant.Definition.ID)) == norm {
+			return VariantSelection{
+				Variant:      variant,
+				DisplayTitle: variant.Definition.Title,
+			}, nil
+		}
+	}
+
+	for _, alias := range entry.LegacyModes {
+		if legacyAliasMatches(alias, norm) {
+			variant, ok := variantByID(entry, alias.TargetVariantID)
+			if !ok {
+				return VariantSelection{}, fmt.Errorf("legacy mode %q targets missing variant %q", alias.Title, alias.TargetVariantID)
+			}
+			elo := alias.PresetElo
+			aliasCopy := alias
+			return VariantSelection{
+				Variant:      variant,
+				ExplicitElo:  &elo,
+				LegacyAlias:  &aliasCopy,
+				DisplayTitle: variant.Definition.Title,
+			}, nil
+		}
+	}
+
+	return VariantSelection{}, fmt.Errorf("unknown variant or legacy mode %q for %s\n\nAvailable variants:\n  %s",
+		name, entry.Definition.Name, strings.Join(VariantNames(entry), "\n  "))
+}
+
+func legacyAliasMatches(alias puzzle.LegacyModeAlias, norm string) bool {
+	if Normalize(alias.Title) == norm || Normalize(string(alias.ID)) == norm {
+		return true
+	}
+	for _, cliAlias := range alias.CLIAliases {
+		if Normalize(cliAlias) == norm {
+			return true
+		}
+	}
+	return false
+}
+
+func variantByID(entry registry.Entry, id puzzle.VariantID) (registry.VariantEntry, bool) {
+	for _, variant := range entry.Variants {
+		if variant.Definition.ID == id {
+			return variant, true
+		}
+	}
+	return registry.VariantEntry{}, false
+}
+
 // ModeNames returns the display names of all modes in an entry.
 func ModeNames(entry registry.Entry) []string {
 	names := make([]string, 0, len(entry.Modes))
 	for _, mode := range entry.Modes {
 		names = append(names, mode.Definition.Title)
+	}
+	return names
+}
+
+func VariantNames(entry registry.Entry) []string {
+	names := make([]string, 0, len(entry.Variants))
+	for _, variant := range entry.Variants {
+		names = append(names, variant.Definition.Title)
 	}
 	return names
 }
@@ -69,8 +150,8 @@ func seededModeForDefinition(seed string, entry registry.Entry) (seededEntry, bo
 	var bestHash uint64
 	found := false
 
-	for _, mode := range entry.Modes {
-		if mode.Seeded == nil {
+	for _, variant := range entry.Variants {
+		if variant.Seeded == nil {
 			continue
 		}
 		h := fnv.New64a()
@@ -78,14 +159,14 @@ func seededModeForDefinition(seed string, entry registry.Entry) (seededEntry, bo
 		h.Write([]byte{0})
 		h.Write([]byte(entry.Definition.Name))
 		h.Write([]byte{0})
-		h.Write([]byte(mode.Definition.Title))
+		h.Write([]byte(variant.Definition.Title))
 		score := h.Sum64()
 		if !found || score > bestHash {
 			bestHash = score
 			best = seededEntry{
-				spawner:  mode.Seeded,
+				spawner:  variant.Seeded,
 				gameType: entry.Definition.Name,
-				mode:     mode.Definition.Title,
+				mode:     variant.Definition.Title,
 			}
 			found = true
 		}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -21,23 +21,31 @@ func Normalize(s string) string {
 // Mode finds a mode within a game entry by name. If name is empty,
 // returns the first (default) mode.
 func Mode(entry registry.Entry, name string) (game.Spawner, string, error) {
+	mode, err := ModeEntry(entry, name)
+	if err != nil {
+		return nil, "", err
+	}
+	return mode.Spawner, mode.Definition.Title, nil
+}
+
+func ModeEntry(entry registry.Entry, name string) (registry.ModeEntry, error) {
 	if len(entry.Modes) == 0 {
-		return nil, "", fmt.Errorf("game %q has no available modes", entry.Definition.Name)
+		return registry.ModeEntry{}, fmt.Errorf("game %q has no available modes", entry.Definition.Name)
 	}
 
 	if name == "" {
 		mode := entry.Modes[0]
-		return mode.Spawner, mode.Definition.Title, nil
+		return mode, nil
 	}
 
 	norm := Normalize(name)
 	for _, mode := range entry.Modes {
 		if Normalize(mode.Definition.Title) == norm {
-			return mode.Spawner, mode.Definition.Title, nil
+			return mode, nil
 		}
 	}
 
-	return nil, "", fmt.Errorf("unknown mode %q for %s\n\nAvailable modes:\n  %s",
+	return registry.ModeEntry{}, fmt.Errorf("unknown mode %q for %s\n\nAvailable modes:\n  %s",
 		name, entry.Definition.Name, strings.Join(ModeNames(entry), "\n  "))
 }
 

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -18,16 +18,6 @@ func Normalize(s string) string {
 	return puzzle.NormalizeName(s)
 }
 
-// Mode finds a mode within a game entry by name. If name is empty,
-// returns the first (default) mode.
-func Mode(entry registry.Entry, name string) (game.Spawner, string, error) {
-	mode, err := ModeEntry(entry, name)
-	if err != nil {
-		return nil, "", err
-	}
-	return mode.Spawner, mode.Definition.Title, nil
-}
-
 func ModeEntry(entry registry.Entry, name string) (registry.ModeEntry, error) {
 	if len(entry.Modes) == 0 {
 		return registry.ModeEntry{}, fmt.Errorf("game %q has no available modes", entry.Definition.Name)

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -94,6 +94,32 @@ func TestModeNames(t *testing.T) {
 	}
 }
 
+func TestVariantEntryResolvesVariantsAndLegacyAliases(t *testing.T) {
+	entry, ok := registry.Resolve("Sudoku")
+	if !ok {
+		t.Fatal("missing sudoku entry")
+	}
+
+	variant, err := VariantEntry(entry, "sudoku")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if variant.Variant.Definition.Title != "Sudoku" || variant.ExplicitElo != nil {
+		t.Fatalf("variant selection = %#v, want Sudoku without explicit Elo", variant)
+	}
+
+	legacy, err := VariantEntry(entry, "easy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Variant.Definition.Title != "Sudoku" {
+		t.Fatalf("legacy variant = %q, want Sudoku", legacy.Variant.Definition.Title)
+	}
+	if legacy.ExplicitElo == nil || *legacy.ExplicitElo != 600 {
+		t.Fatalf("legacy explicit Elo = %v, want 600", legacy.ExplicitElo)
+	}
+}
+
 func TestRNGFromString(t *testing.T) {
 	rng1 := RNGFromString("hello-world")
 	rng2 := RNGFromString("hello-world")
@@ -146,13 +172,12 @@ func TestSeededModeStableOnEntryChange(t *testing.T) {
 	extended := append([]registry.Entry(nil), testEntries...)
 	extended = append(extended, registry.Entry{
 		Definition: puzzle.Definition{
-			ID:    puzzle.CanonicalGameID("Synthetic"),
-			Name:  "Synthetic",
-			Modes: []puzzle.ModeDef{{ID: puzzle.CanonicalModeID("Easy"), Title: "Easy", Seeded: true}},
+			ID:       puzzle.CanonicalGameID("Synthetic"),
+			Name:     "Synthetic",
+			Variants: []puzzle.VariantDef{{ID: puzzle.CanonicalVariantID("Synthetic"), Title: "Synthetic"}},
 		},
-		Modes: []registry.ModeEntry{{
-			Definition: puzzle.ModeDef{ID: puzzle.CanonicalModeID("Easy"), Title: "Easy", Seeded: true},
-			Spawner:    lightsout.Modes[0].(game.Spawner),
+		Variants: []registry.VariantEntry{{
+			Definition: puzzle.VariantDef{ID: puzzle.CanonicalVariantID("Synthetic"), Title: "Synthetic"},
 			Seeded:     lightsout.Modes[0].(game.SeededSpawner),
 		}},
 	})

--- a/resolve/resolve_test.go
+++ b/resolve/resolve_test.go
@@ -33,34 +33,34 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
-func TestMode(t *testing.T) {
+func TestModeEntry(t *testing.T) {
 	sudokuEntry, ok := registry.Resolve("Sudoku")
 	if !ok {
 		t.Fatal("missing sudoku entry")
 	}
 
 	t.Run("empty name returns default (first) mode", func(t *testing.T) {
-		spawner, title, err := Mode(sudokuEntry, "")
+		mode, err := ModeEntry(sudokuEntry, "")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if spawner == nil || title != "Beginner" {
-			t.Fatalf("default mode = (%v, %q), want Beginner", spawner != nil, title)
+		if mode.Spawner == nil || mode.Definition.Title != "Beginner" {
+			t.Fatalf("default mode = (%v, %q), want Beginner", mode.Spawner != nil, mode.Definition.Title)
 		}
 	})
 
 	t.Run("case insensitive match", func(t *testing.T) {
-		_, title, err := Mode(sudokuEntry, "easy")
+		mode, err := ModeEntry(sudokuEntry, "easy")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if title != "Easy" {
-			t.Fatalf("title = %q, want Easy", title)
+		if mode.Definition.Title != "Easy" {
+			t.Fatalf("title = %q, want Easy", mode.Definition.Title)
 		}
 	})
 
 	t.Run("unknown mode", func(t *testing.T) {
-		_, _, err := Mode(sudokuEntry, "impossible")
+		_, err := ModeEntry(sudokuEntry, "impossible")
 		if err == nil || !strings.Contains(err.Error(), "unknown mode") {
 			t.Fatalf("error = %v, want unknown mode", err)
 		}
@@ -70,7 +70,7 @@ func TestMode(t *testing.T) {
 		emptyEntry := registry.Entry{
 			Definition: puzzle.Definition{Name: "Empty"},
 		}
-		_, _, err := Mode(emptyEntry, "any")
+		_, err := ModeEntry(emptyEntry, "any")
 		if err == nil || !strings.Contains(err.Error(), "no available modes") {
 			t.Fatalf("error = %v, want no available modes", err)
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -117,6 +117,8 @@ func CreateRecordWithDifficulty(
 		Name:         name,
 		GameID:       string(puzzle.CanonicalGameID(gameType)),
 		GameType:     gameType,
+		VariantID:    string(puzzle.CanonicalVariantID(modeTitle)),
+		Variant:      modeTitle,
 		ModeID:       string(puzzle.CanonicalModeID(modeTitle)),
 		Mode:         modeTitle,
 		InitialState: string(initialState),

--- a/session/session.go
+++ b/session/session.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/game"
 	"github.com/FelineStateMachine/puzzletea/namegen"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
@@ -12,6 +13,12 @@ import (
 	"github.com/FelineStateMachine/puzzletea/resolve"
 	"github.com/FelineStateMachine/puzzletea/store"
 )
+
+type DifficultyMetadata struct {
+	TargetElo  *difficulty.Elo
+	ActualElo  *difficulty.Elo
+	Confidence difficulty.Confidence
+}
 
 // NormalizeSeed keeps seeded names distinct from real dailies.
 func NormalizeSeed(seed string) string {
@@ -46,6 +53,27 @@ func SeededNameForGame(seed, gameType string) string {
 	)
 }
 
+// SeededNameForCreateLeaf derives the deterministic display name for a seeded
+// puzzle locked to one Create leaf and target Elo.
+func SeededNameForCreateLeaf(seed, gameType, leafID string, elo difficulty.Elo) string {
+	if strings.TrimSpace(leafID) == "" {
+		return SeededNameForGame(seed, gameType)
+	}
+
+	scope := strings.Join([]string{
+		game.NormalizeName(gameType),
+		puzzle.NormalizeName(leafID),
+		strconv.Itoa(int(elo)),
+	}, ":")
+	nameRNG := resolve.RNGFromString("name:" + seed + ":" + scope)
+	return fmt.Sprintf("%s [%s %d] - %s",
+		seed,
+		gameType,
+		elo,
+		namegen.GenerateSeeded(nameRNG),
+	)
+}
+
 // ImportRecord reconstructs a saved game and reapplies the record title.
 func ImportRecord(rec *store.GameRecord) (game.Gamer, error) {
 	if rec == nil {
@@ -68,6 +96,18 @@ func CreateRecord(
 	modeTitle string,
 	run store.RunMetadata,
 ) (*store.GameRecord, error) {
+	return CreateRecordWithDifficulty(s, g, name, gameType, modeTitle, run, DifficultyMetadata{})
+}
+
+func CreateRecordWithDifficulty(
+	s *store.Store,
+	g game.Gamer,
+	name string,
+	gameType string,
+	modeTitle string,
+	run store.RunMetadata,
+	difficultyMeta DifficultyMetadata,
+) (*store.GameRecord, error) {
 	initialState, err := g.GetSave()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get initial save: %w", err)
@@ -89,6 +129,15 @@ func CreateRecord(
 		WeekIndex:    run.WeekIndex,
 		SeedText:     run.SeedText,
 	}
+	if difficultyMeta.TargetElo != nil {
+		v := int(*difficultyMeta.TargetElo)
+		rec.TargetDifficultyElo = &v
+	}
+	if difficultyMeta.ActualElo != nil {
+		v := int(*difficultyMeta.ActualElo)
+		rec.ActualDifficultyElo = &v
+	}
+	rec.DifficultyConfidence = string(difficultyMeta.Confidence)
 	if err := s.CreateGame(rec); err != nil {
 		return nil, fmt.Errorf("failed to create game record: %w", err)
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -48,6 +48,20 @@ func TestSeededNameForGameDeterministicAndDistinct(t *testing.T) {
 	}
 }
 
+func TestSeededNameForCreateLeafDeterministicAndDistinctByScope(t *testing.T) {
+	seed := "create-seed"
+	got := SeededNameForCreateLeaf(seed, "Nonogram", "nonogram/5x5", 1200)
+	if want := SeededNameForCreateLeaf(seed, "Nonogram", "nonogram/5x5", 1200); got != want {
+		t.Fatalf("SeededNameForCreateLeaf returned %q then %q", got, want)
+	}
+	if got == SeededNameForCreateLeaf(seed, "Nonogram", "nonogram/10x10", 1200) {
+		t.Fatal("SeededNameForCreateLeaf should differ by leaf")
+	}
+	if got == SeededNameForCreateLeaf(seed, "Nonogram", "nonogram/5x5", 1300) {
+		t.Fatal("SeededNameForCreateLeaf should differ by Elo")
+	}
+}
+
 func TestImportRecordReappliesTitle(t *testing.T) {
 	g, err := lightsout.New(3, 3)
 	if err != nil {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -21,11 +21,18 @@ type Weights map[ModeKey]int
 func WeightsFromDefinitions(definitions []puzzle.Definition) Weights {
 	weights := make(Weights, 64)
 	for _, def := range definitions {
-		count := len(def.Modes)
-		for i, mode := range def.Modes {
-			xp := int(math.Round(float64(i) / float64(count) * 10))
-			xp = max(xp, 1)
-			weights[ModeKey{GameType: def.Name, Mode: mode.Title}] = xp
+		count := len(def.Variants)
+		if count > 0 {
+			for i, variant := range def.Variants {
+				xp := int(math.Round(float64(i) / float64(count) * 10))
+				xp = max(xp, 1)
+				weights[ModeKey{GameType: def.Name, Mode: variant.Title}] = xp
+			}
+		}
+		for _, mode := range def.Modes {
+			if _, ok := weights[ModeKey{GameType: def.Name, Mode: mode.Title}]; !ok {
+				weights[ModeKey{GameType: def.Name, Mode: mode.Title}] = 1
+			}
 		}
 	}
 	return weights

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/FelineStateMachine/puzzletea/difficulty"
 	"github.com/FelineStateMachine/puzzletea/puzzle"
 	"github.com/FelineStateMachine/puzzletea/store"
 )
@@ -56,16 +57,25 @@ func ComputeCategoryXP(weights Weights, gameType string, modeStats []store.ModeS
 		if ms.GameType != gameType {
 			continue
 		}
-		baseXP := weights[ModeKey{ms.GameType, ms.Mode}]
-		if baseXP == 0 {
-			baseXP = 1
-		}
+		baseXP := modeStatXP(weights, ms)
 		normalVictories := ms.Victories - ms.DailyVictories
 		total += normalVictories * baseXP
 		total += ms.DailyVictories * baseXP * 2
 		total += ms.WeeklyBonusXP
 	}
 	return total
+}
+
+func modeStatXP(weights Weights, ms store.ModeStat) int {
+	if ms.DifficultyElo != nil {
+		score := difficulty.Score01(difficulty.Elo(*ms.DifficultyElo))
+		return max(1, int(math.Round(score*10)))
+	}
+	baseXP := weights[ModeKey{ms.GameType, ms.Mode}]
+	if baseXP == 0 {
+		return 1
+	}
+	return baseXP
 }
 
 // ComputeDailyStreak calculates the length of the current daily completion

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -29,13 +29,31 @@ func WeightsFromDefinitions(definitions []puzzle.Definition) Weights {
 				weights[ModeKey{GameType: def.Name, Mode: variant.Title}] = xp
 			}
 		}
+		for _, alias := range def.LegacyModes {
+			weights[ModeKey{GameType: def.Name, Mode: alias.Title}] = max(alias.XPWeight, 1)
+		}
 		for _, mode := range def.Modes {
 			if _, ok := weights[ModeKey{GameType: def.Name, Mode: mode.Title}]; !ok {
-				weights[ModeKey{GameType: def.Name, Mode: mode.Title}] = 1
+				weights[ModeKey{GameType: def.Name, Mode: mode.Title}] = legacyModeXPWeight(mode, def.Modes)
 			}
 		}
 	}
 	return weights
+}
+
+func legacyModeXPWeight(mode puzzle.ModeDef, modes []puzzle.ModeDef) int {
+	count := len(modes)
+	if count == 0 {
+		return 1
+	}
+	for i, candidate := range modes {
+		if candidate.ID != mode.ID {
+			continue
+		}
+		xp := int(math.Round(float64(i) / float64(count) * 10))
+		return max(xp, 1)
+	}
+	return 1
 }
 
 // LevelFromXP returns the level for the given total XP.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -22,6 +22,41 @@ func TestWeightsFromDefinitions(t *testing.T) {
 	}
 }
 
+func TestWeightsFromDefinitionsPreservesLegacyModeWeights(t *testing.T) {
+	weights := WeightsFromDefinitions([]puzzle.Definition{{
+		Name: "Sudoku",
+		Variants: []puzzle.VariantDef{
+			puzzle.NewVariantDef(puzzle.VariantSpec{Title: "Sudoku", DefaultElo: 1200}),
+		},
+		LegacyModes: []puzzle.LegacyModeAlias{
+			puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+				Title:           "Easy",
+				TargetVariantID: puzzle.CanonicalVariantID("Sudoku"),
+				PresetElo:       600,
+				XPWeight:        1,
+			}),
+			puzzle.NewLegacyModeAlias(puzzle.LegacyModeAliasSpec{
+				Title:           "Hard",
+				TargetVariantID: puzzle.CanonicalVariantID("Sudoku"),
+				PresetElo:       1800,
+				XPWeight:        7,
+			}),
+		},
+		Modes: []puzzle.ModeDef{
+			{ID: puzzle.CanonicalModeID("Easy"), Title: "Easy"},
+			{ID: puzzle.CanonicalModeID("Medium"), Title: "Medium"},
+			{ID: puzzle.CanonicalModeID("Hard"), Title: "Hard"},
+		},
+	}})
+
+	if got, want := weights[ModeKey{GameType: "Sudoku", Mode: "Hard"}], 7; got != want {
+		t.Fatalf("legacy Hard weight = %d, want %d", got, want)
+	}
+	if got, want := weights[ModeKey{GameType: "Sudoku", Mode: "Sudoku"}], 1; got != want {
+		t.Fatalf("variant weight = %d, want %d", got, want)
+	}
+}
+
 func TestLevelFromXPAndXPForLevel(t *testing.T) {
 	if got := LevelFromXP(0); got != 0 {
 		t.Fatalf("LevelFromXP(0) = %d, want 0", got)

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -55,6 +55,12 @@ func TestComputeCategoryXP(t *testing.T) {
 	if got := ComputeCategoryXP(weights, "Sudoku", modeStats); got != 30 {
 		t.Fatalf("ComputeCategoryXP() = %d, want 30", got)
 	}
+
+	elo := 1500
+	modeStats[0].DifficultyElo = &elo
+	if got := ComputeCategoryXP(weights, "Sudoku", modeStats); got != 51 {
+		t.Fatalf("ComputeCategoryXP() with Elo = %d, want 51", got)
+	}
 }
 
 func TestBuildCardsAndProfile(t *testing.T) {

--- a/store/game_record.go
+++ b/store/game_record.go
@@ -33,6 +33,8 @@ type GameRecord struct {
 	Name                 string
 	GameID               string
 	GameType             string
+	VariantID            string
+	Variant              string
 	ModeID               string
 	Mode                 string
 	InitialState         string

--- a/store/game_record.go
+++ b/store/game_record.go
@@ -29,22 +29,25 @@ const (
 )
 
 type GameRecord struct {
-	ID           int64
-	Name         string
-	GameID       string
-	GameType     string
-	ModeID       string
-	Mode         string
-	InitialState string
-	SaveState    string
-	Status       GameStatus
-	RunKind      RunKind
-	RunDate      *time.Time
-	WeekYear     int
-	WeekNumber   int
-	WeekIndex    int
-	SeedText     string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	CompletedAt  *time.Time
+	ID                   int64
+	Name                 string
+	GameID               string
+	GameType             string
+	ModeID               string
+	Mode                 string
+	InitialState         string
+	SaveState            string
+	Status               GameStatus
+	RunKind              RunKind
+	RunDate              *time.Time
+	WeekYear             int
+	WeekNumber           int
+	WeekIndex            int
+	SeedText             string
+	TargetDifficultyElo  *int
+	ActualDifficultyElo  *int
+	DifficultyConfidence string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
 }

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const currentSchemaVersion = 4
+const currentSchemaVersion = 5
 
 type migration struct {
 	version int
@@ -18,6 +18,7 @@ var schemaMigrations = []migration{
 	{version: 2, name: "add game metadata columns", apply: migrateGameMetadata},
 	{version: 3, name: "refresh stats views", apply: refreshStatsViews},
 	{version: 4, name: "add difficulty metadata", apply: migrateDifficultyMetadata},
+	{version: 5, name: "add variant metadata", apply: migrateVariantMetadata},
 }
 
 type gameRowMeta struct {
@@ -137,8 +138,13 @@ func detectSchemaVersion(db *sql.DB) (int, error) {
 			return 2, nil
 		}
 	}
+	for _, column := range []string{"variant_id", "variant"} {
+		if !columns[column] {
+			return 4, nil
+		}
+	}
 
-	return 4, nil
+	return 5, nil
 }
 
 func createGamesSchema(db *sql.DB) error {
@@ -181,12 +187,24 @@ func migrateDifficultyMetadata(db *sql.DB) error {
 	return refreshStatsViews(db)
 }
 
+func migrateVariantMetadata(db *sql.DB) error {
+	if err := ensureVariantColumns(db); err != nil {
+		return err
+	}
+	if err := backfillVariantMetadata(db); err != nil {
+		return err
+	}
+	return refreshStatsViews(db)
+}
+
 func ensureGameColumns(db *sql.DB) error {
 	columns := []struct {
 		name       string
 		definition string
 	}{
 		{name: "game_id", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "variant_id", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "variant", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "mode_id", definition: "TEXT NOT NULL DEFAULT ''"},
 		{name: "run_kind", definition: "TEXT NOT NULL DEFAULT 'normal'"},
 		{name: "run_date", definition: "DATE"},
@@ -194,6 +212,30 @@ func ensureGameColumns(db *sql.DB) error {
 		{name: "week_number", definition: "INTEGER"},
 		{name: "week_index", definition: "INTEGER"},
 		{name: "seed_text", definition: "TEXT"},
+	}
+
+	existing, err := tableColumns(db, "games")
+	if err != nil {
+		return err
+	}
+	for _, column := range columns {
+		if existing[column.name] {
+			continue
+		}
+		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE games ADD COLUMN %s %s", column.name, column.definition)); err != nil {
+			return fmt.Errorf("adding games.%s: %w", column.name, err)
+		}
+	}
+	return nil
+}
+
+func ensureVariantColumns(db *sql.DB) error {
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "variant_id", definition: "TEXT NOT NULL DEFAULT ''"},
+		{name: "variant", definition: "TEXT NOT NULL DEFAULT ''"},
 	}
 
 	existing, err := tableColumns(db, "games")
@@ -232,6 +274,23 @@ func ensureDifficultyColumns(db *sql.DB) error {
 		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE games ADD COLUMN %s %s", column.name, column.definition)); err != nil {
 			return fmt.Errorf("adding games.%s: %w", column.name, err)
 		}
+	}
+	return nil
+}
+
+func backfillVariantMetadata(db *sql.DB) error {
+	_, err := db.Exec(`
+UPDATE games
+   SET variant = CASE WHEN variant = '' THEN mode ELSE variant END,
+       variant_id = CASE
+           WHEN variant_id != '' THEN variant_id
+           WHEN mode_id != '' THEN mode_id
+           ELSE lower(trim(replace(replace(mode, '-', ' '), '_', ' ')))
+       END
+ WHERE variant = ''
+    OR variant_id = ''`)
+	if err != nil {
+		return fmt.Errorf("backfilling variant metadata: %w", err)
 	}
 	return nil
 }

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const currentSchemaVersion = 3
+const currentSchemaVersion = 4
 
 type migration struct {
 	version int
@@ -17,6 +17,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "create games table", apply: createGamesSchema},
 	{version: 2, name: "add game metadata columns", apply: migrateGameMetadata},
 	{version: 3, name: "refresh stats views", apply: refreshStatsViews},
+	{version: 4, name: "add difficulty metadata", apply: migrateDifficultyMetadata},
 }
 
 type gameRowMeta struct {
@@ -131,8 +132,13 @@ func detectSchemaVersion(db *sql.DB) (int, error) {
 			return 1, nil
 		}
 	}
+	for _, column := range []string{"target_difficulty_elo", "actual_difficulty_elo", "difficulty_confidence"} {
+		if !columns[column] {
+			return 2, nil
+		}
+	}
 
-	return 2, nil
+	return 4, nil
 }
 
 func createGamesSchema(db *sql.DB) error {
@@ -168,6 +174,13 @@ func refreshStatsViews(db *sql.DB) error {
 	return nil
 }
 
+func migrateDifficultyMetadata(db *sql.DB) error {
+	if err := ensureDifficultyColumns(db); err != nil {
+		return err
+	}
+	return refreshStatsViews(db)
+}
+
 func ensureGameColumns(db *sql.DB) error {
 	columns := []struct {
 		name       string
@@ -181,6 +194,31 @@ func ensureGameColumns(db *sql.DB) error {
 		{name: "week_number", definition: "INTEGER"},
 		{name: "week_index", definition: "INTEGER"},
 		{name: "seed_text", definition: "TEXT"},
+	}
+
+	existing, err := tableColumns(db, "games")
+	if err != nil {
+		return err
+	}
+	for _, column := range columns {
+		if existing[column.name] {
+			continue
+		}
+		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE games ADD COLUMN %s %s", column.name, column.definition)); err != nil {
+			return fmt.Errorf("adding games.%s: %w", column.name, err)
+		}
+	}
+	return nil
+}
+
+func ensureDifficultyColumns(db *sql.DB) error {
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "target_difficulty_elo", definition: "INTEGER"},
+		{name: "actual_difficulty_elo", definition: "INTEGER"},
+		{name: "difficulty_confidence", definition: "TEXT"},
 	}
 
 	existing, err := tableColumns(db, "games")
@@ -290,6 +328,13 @@ func nullableInt(value int) any {
 		return nil
 	}
 	return value
+}
+
+func nullableIntPtr(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
 }
 
 func nullableIntIf(ok bool, value int) any {

--- a/store/stats.go
+++ b/store/stats.go
@@ -23,6 +23,7 @@ type ModeStat struct {
 	Mode           string
 	Victories      int
 	DailyVictories int
+	DifficultyElo  *int
 	WeeklyBonusXP  int
 }
 
@@ -61,7 +62,7 @@ func (s *Store) GetCategoryStats() ([]CategoryStat, error) {
 // GetModeStats returns per-mode victory counts from the mode_stats view.
 func (s *Store) GetModeStats() ([]ModeStat, error) {
 	rows, err := s.db.Query(
-		`SELECT game_type, mode, victories, daily_victories
+		`SELECT game_type, mode, victories, daily_victories, difficulty_elo
 		 FROM mode_stats`,
 	)
 	if err != nil {
@@ -72,10 +73,16 @@ func (s *Store) GetModeStats() ([]ModeStat, error) {
 	var stats []ModeStat
 	for rows.Next() {
 		var ms ModeStat
+		var difficultyElo sql.NullInt64
 		if err := rows.Scan(
 			&ms.GameType, &ms.Mode, &ms.Victories, &ms.DailyVictories,
+			&difficultyElo,
 		); err != nil {
 			return nil, fmt.Errorf("scanning mode_stats row: %w", err)
+		}
+		if difficultyElo.Valid {
+			v := int(difficultyElo.Int64)
+			ms.DifficultyElo = &v
 		}
 		stats = append(stats, ms)
 	}

--- a/store/stats_test.go
+++ b/store/stats_test.go
@@ -221,6 +221,45 @@ func TestGetModeStats(t *testing.T) {
 			t.Fatal("expected Sudoku/Easy mode stats")
 		}
 	})
+
+	t.Run("difficulty elo averages completed records", func(t *testing.T) {
+		s := openTestStore(t)
+		first := newTestRecord("elo-a")
+		second := newTestRecord("elo-b")
+		incomplete := newTestRecord("elo-c")
+		for _, rec := range []*GameRecord{first, second, incomplete} {
+			rec.GameType = "Word Search"
+			rec.Mode = "Easy 10x10"
+		}
+		firstActual := 1200
+		secondTarget := 1800
+		incompleteActual := 3000
+		first.ActualDifficultyElo = &firstActual
+		second.TargetDifficultyElo = &secondTarget
+		incomplete.ActualDifficultyElo = &incompleteActual
+
+		for _, rec := range []*GameRecord{first, second, incomplete} {
+			if err := s.CreateGame(rec); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, id := range []int64{first.ID, second.ID} {
+			if err := s.UpdateStatus(id, StatusCompleted); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		stats, err := s.GetModeStats()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(stats) != 1 {
+			t.Fatalf("stats length = %d, want 1", len(stats))
+		}
+		if stats[0].DifficultyElo == nil || *stats[0].DifficultyElo != 1500 {
+			t.Fatalf("DifficultyElo = %v, want 1500", stats[0].DifficultyElo)
+		}
+	})
 }
 
 // --- GetDailyStreakDates (P1) ---

--- a/store/store.go
+++ b/store/store.go
@@ -31,6 +31,9 @@ CREATE TABLE IF NOT EXISTS games (
     week_number   INTEGER,
     week_index    INTEGER,
     seed_text     TEXT,
+    target_difficulty_elo INTEGER,
+    actual_difficulty_elo INTEGER,
+    difficulty_confidence TEXT,
     created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     completed_at  DATETIME
@@ -62,7 +65,10 @@ SELECT
     mode,
     COUNT(*) FILTER (WHERE status = 'completed')          AS victories,
     COUNT(*) FILTER (WHERE status = 'completed'
-                       AND run_kind = 'daily')            AS daily_victories
+                       AND run_kind = 'daily')            AS daily_victories,
+    CAST(ROUND(AVG(COALESCE(actual_difficulty_elo, target_difficulty_elo))
+        FILTER (WHERE status = 'completed'
+                  AND COALESCE(actual_difficulty_elo, target_difficulty_elo) IS NOT NULL)) AS INTEGER) AS difficulty_elo
 FROM games
 GROUP BY game_type, mode;`
 
@@ -72,6 +78,7 @@ type Store struct {
 
 const gameSelectColumns = `id, name, game_id, game_type, mode_id, mode, initial_state, save_state,
         status, run_kind, run_date, week_year, week_number, week_index, seed_text,
+        target_difficulty_elo, actual_difficulty_elo, difficulty_confidence,
         created_at, updated_at, completed_at`
 
 type rowScanner interface {
@@ -85,11 +92,15 @@ func scanGameRecord(scanner rowScanner) (GameRecord, error) {
 	var weekNumber sql.NullInt64
 	var weekIndex sql.NullInt64
 	var seedText sql.NullString
+	var targetDifficultyElo sql.NullInt64
+	var actualDifficultyElo sql.NullInt64
+	var difficultyConfidence sql.NullString
 	var completedAt sql.NullTime
 	if err := scanner.Scan(
 		&g.ID, &g.Name, &g.GameID, &g.GameType, &g.ModeID, &g.Mode,
 		&g.InitialState, &g.SaveState, &g.Status,
 		&g.RunKind, &runDate, &weekYear, &weekNumber, &weekIndex, &seedText,
+		&targetDifficultyElo, &actualDifficultyElo, &difficultyConfidence,
 		&g.CreatedAt, &g.UpdatedAt, &completedAt,
 	); err != nil {
 		return GameRecord{}, err
@@ -109,6 +120,17 @@ func scanGameRecord(scanner rowScanner) (GameRecord, error) {
 	}
 	if seedText.Valid {
 		g.SeedText = seedText.String
+	}
+	if targetDifficultyElo.Valid {
+		v := int(targetDifficultyElo.Int64)
+		g.TargetDifficultyElo = &v
+	}
+	if actualDifficultyElo.Valid {
+		v := int(actualDifficultyElo.Int64)
+		g.ActualDifficultyElo = &v
+	}
+	if difficultyConfidence.Valid {
+		g.DifficultyConfidence = difficultyConfidence.String
 	}
 	if completedAt.Valid {
 		g.CompletedAt = &completedAt.Time
@@ -186,11 +208,13 @@ func (s *Store) CreateGame(rec *GameRecord) error {
 	result, err := s.db.Exec(
 		`INSERT INTO games
 		    (name, game_id, game_type, mode_id, mode, initial_state, save_state, status,
-		     run_kind, run_date, week_year, week_number, week_index, seed_text)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		     run_kind, run_date, week_year, week_number, week_index, seed_text,
+		     target_difficulty_elo, actual_difficulty_elo, difficulty_confidence)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		rec.Name, rec.GameID, rec.GameType, rec.ModeID, rec.Mode,
 		rec.InitialState, rec.SaveState, rec.Status, string(rec.RunKind), rec.RunDate,
 		nullableInt(rec.WeekYear), nullableInt(rec.WeekNumber), nullableInt(rec.WeekIndex), nullableString(rec.SeedText),
+		nullableIntPtr(rec.TargetDifficultyElo), nullableIntPtr(rec.ActualDifficultyElo), nullableString(rec.DifficultyConfidence),
 	)
 	if err != nil {
 		return fmt.Errorf("inserting game: %w", err)

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS games (
     name          TEXT    NOT NULL UNIQUE,
     game_id       TEXT    NOT NULL DEFAULT '',
     game_type     TEXT    NOT NULL,
+    variant_id    TEXT    NOT NULL DEFAULT '',
+    variant       TEXT    NOT NULL DEFAULT '',
     mode_id       TEXT    NOT NULL DEFAULT '',
     mode          TEXT    NOT NULL,
     initial_state TEXT    NOT NULL,
@@ -49,11 +51,11 @@ SELECT
     COUNT(*) FILTER (WHERE run_kind = 'daily')            AS times_daily,
     COUNT(*) FILTER (WHERE status = 'completed'
                        AND run_kind = 'daily')            AS daily_victories,
-    (SELECT mode FROM games g2
+    (SELECT COALESCE(NULLIF(variant, ''), mode) FROM games g2
      WHERE g2.game_type = games.game_type
        AND g2.status = 'completed'
-     GROUP BY mode
-     ORDER BY COUNT(*) DESC, mode ASC
+     GROUP BY COALESCE(NULLIF(variant, ''), mode)
+     ORDER BY COUNT(*) DESC, COALESCE(NULLIF(variant, ''), mode) ASC
      LIMIT 1)                                             AS preferred_mode
 FROM games
 GROUP BY game_type;`
@@ -62,7 +64,7 @@ const createModeStatsViewSQL = `
 CREATE VIEW IF NOT EXISTS mode_stats AS
 SELECT
     game_type,
-    mode,
+    COALESCE(NULLIF(variant, ''), mode)                    AS mode,
     COUNT(*) FILTER (WHERE status = 'completed')          AS victories,
     COUNT(*) FILTER (WHERE status = 'completed'
                        AND run_kind = 'daily')            AS daily_victories,
@@ -70,13 +72,13 @@ SELECT
         FILTER (WHERE status = 'completed'
                   AND COALESCE(actual_difficulty_elo, target_difficulty_elo) IS NOT NULL)) AS INTEGER) AS difficulty_elo
 FROM games
-GROUP BY game_type, mode;`
+GROUP BY game_type, COALESCE(NULLIF(variant, ''), mode);`
 
 type Store struct {
 	db *sql.DB
 }
 
-const gameSelectColumns = `id, name, game_id, game_type, mode_id, mode, initial_state, save_state,
+const gameSelectColumns = `id, name, game_id, game_type, variant_id, variant, mode_id, mode, initial_state, save_state,
         status, run_kind, run_date, week_year, week_number, week_index, seed_text,
         target_difficulty_elo, actual_difficulty_elo, difficulty_confidence,
         created_at, updated_at, completed_at`
@@ -97,7 +99,7 @@ func scanGameRecord(scanner rowScanner) (GameRecord, error) {
 	var difficultyConfidence sql.NullString
 	var completedAt sql.NullTime
 	if err := scanner.Scan(
-		&g.ID, &g.Name, &g.GameID, &g.GameType, &g.ModeID, &g.Mode,
+		&g.ID, &g.Name, &g.GameID, &g.GameType, &g.VariantID, &g.Variant, &g.ModeID, &g.Mode,
 		&g.InitialState, &g.SaveState, &g.Status,
 		&g.RunKind, &runDate, &weekYear, &weekNumber, &weekIndex, &seedText,
 		&targetDifficultyElo, &actualDifficultyElo, &difficultyConfidence,
@@ -201,17 +203,23 @@ func (s *Store) CreateGame(rec *GameRecord) error {
 	if rec.ModeID == "" {
 		rec.ModeID = CanonicalModeID(rec.Mode)
 	}
+	if rec.Variant == "" {
+		rec.Variant = rec.Mode
+	}
+	if rec.VariantID == "" {
+		rec.VariantID = CanonicalModeID(rec.Variant)
+	}
 	if rec.RunKind == "" {
 		rec.RunKind = RunKindNormal
 	}
 
 	result, err := s.db.Exec(
 		`INSERT INTO games
-		    (name, game_id, game_type, mode_id, mode, initial_state, save_state, status,
+		    (name, game_id, game_type, variant_id, variant, mode_id, mode, initial_state, save_state, status,
 		     run_kind, run_date, week_year, week_number, week_index, seed_text,
 		     target_difficulty_elo, actual_difficulty_elo, difficulty_confidence)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		rec.Name, rec.GameID, rec.GameType, rec.ModeID, rec.Mode,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.Name, rec.GameID, rec.GameType, rec.VariantID, rec.Variant, rec.ModeID, rec.Mode,
 		rec.InitialState, rec.SaveState, rec.Status, string(rec.RunKind), rec.RunDate,
 		nullableInt(rec.WeekYear), nullableInt(rec.WeekNumber), nullableInt(rec.WeekIndex), nullableString(rec.SeedText),
 		nullableIntPtr(rec.TargetDifficultyElo), nullableIntPtr(rec.ActualDifficultyElo), nullableString(rec.DifficultyConfidence),

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -171,6 +171,12 @@ VALUES (?, ?, ?, ?, ?, ?)`,
 		if got, want := rec.ModeID, "easy"; got != want {
 			t.Fatalf("ModeID = %q, want %q", got, want)
 		}
+		if got, want := rec.VariantID, "easy"; got != want {
+			t.Fatalf("VariantID = %q, want %q", got, want)
+		}
+		if got, want := rec.Variant, "Easy"; got != want {
+			t.Fatalf("Variant = %q, want %q", got, want)
+		}
 		if got, want := rec.RunKind, RunKindDaily; got != want {
 			t.Fatalf("RunKind = %q, want %q", got, want)
 		}
@@ -246,6 +252,12 @@ func TestCreateGame(t *testing.T) {
 		}
 		if got.Mode != "Hard 10x10" {
 			t.Errorf("Mode = %q, want %q", got.Mode, "Hard 10x10")
+		}
+		if got.Variant != "Hard 10x10" {
+			t.Errorf("Variant = %q, want %q", got.Variant, "Hard 10x10")
+		}
+		if got.VariantID != "hard 10x10" {
+			t.Errorf("VariantID = %q, want %q", got.VariantID, "hard 10x10")
 		}
 		if got.InitialState != `{"init":true}` {
 			t.Errorf("InitialState = %q, want %q", got.InitialState, `{"init":true}`)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -222,6 +222,11 @@ func TestCreateGame(t *testing.T) {
 			Status:       StatusNew,
 			RunKind:      RunKindNormal,
 		}
+		targetElo := 1200
+		actualElo := 1185
+		rec.TargetDifficultyElo = &targetElo
+		rec.ActualDifficultyElo = &actualElo
+		rec.DifficultyConfidence = "high"
 		if err := s.CreateGame(rec); err != nil {
 			t.Fatal(err)
 		}
@@ -247,6 +252,15 @@ func TestCreateGame(t *testing.T) {
 		}
 		if got.SaveState != `{"save":true}` {
 			t.Errorf("SaveState = %q, want %q", got.SaveState, `{"save":true}`)
+		}
+		if got.TargetDifficultyElo == nil || *got.TargetDifficultyElo != targetElo {
+			t.Fatalf("TargetDifficultyElo = %v, want %d", got.TargetDifficultyElo, targetElo)
+		}
+		if got.ActualDifficultyElo == nil || *got.ActualDifficultyElo != actualElo {
+			t.Fatalf("ActualDifficultyElo = %v, want %d", got.ActualDifficultyElo, actualElo)
+		}
+		if got.DifficultyConfidence != "high" {
+			t.Fatalf("DifficultyConfidence = %q, want high", got.DifficultyConfidence)
 		}
 		if got.Status != StatusNew {
 			t.Errorf("Status = %q, want %q", got.Status, StatusNew)

--- a/weekly/weekly_test.go
+++ b/weekly/weekly_test.go
@@ -95,7 +95,7 @@ func TestBonusXP(t *testing.T) {
 	}
 }
 
-func TestEligibleModesIncludeSudokuRGBDailyTiers(t *testing.T) {
+func TestEligibleModesIncludeSudokuRGBVariant(t *testing.T) {
 	found := map[string]bool{}
 	for _, entry := range eligibleModes {
 		if entry.GameType == "Sudoku RGB" {
@@ -103,9 +103,7 @@ func TestEligibleModesIncludeSudokuRGBDailyTiers(t *testing.T) {
 		}
 	}
 
-	for _, mode := range []string{"Easy", "Medium"} {
-		if !found[mode] {
-			t.Fatalf("eligibleModes missing Sudoku RGB %s", mode)
-		}
+	if !found["Sudoku RGB"] {
+		t.Fatalf("eligibleModes missing Sudoku RGB variant")
 	}
 }


### PR DESCRIPTION
## Summary
- Prepare the v2.0 release branch with Elo-backed difficulty metadata, validation, save/export plumbing, and PDF JSONL handling.
- Add Elo-targeted generation and scoring hooks across the built-in puzzle modes, with mode presets preserved as compatibility-friendly aliases.
- Replace the old separate Seeded menu entry with the Create flow for checked puzzle pools, target Elo selection, and seeded single-leaf generation.
- Carry Elo metadata into persistence, stats/XP, JSONL packs, and PDF ordering/difficulty rendering.

## Docs
- Update the top-level README for the v2 Create flow, CLI `--difficulty`, export metadata, and game implementation guidance.
- Add Elo difficulty notes to each game README.
- Refresh stale README links for game docs and font license paths, and include Takuzu+ in the preview list.
- Preserve research references for public puzzle implementations and solver docs used to inform heuristics.

## Validation
- `just fmt`
- `just lint`
- `just test-short`
